### PR TITLE
✨ feat: 获取当前是否有选区，和选区部分的内容

### DIFF
--- a/src/editor-kernel/data-source.ts
+++ b/src/editor-kernel/data-source.ts
@@ -2,6 +2,11 @@
 /* eslint-disable unused-imports/no-unused-vars */
 import { LexicalEditor } from 'lexical';
 
+export interface IWriteOptions {
+  // get selection data
+  selection?: boolean;
+}
+
 export default class DataSource {
   constructor(protected dataType: string) {}
 
@@ -11,7 +16,7 @@ export default class DataSource {
 
   read(editor: LexicalEditor, data: any) {}
 
-  write(editor: LexicalEditor): any {
+  write(editor: LexicalEditor, options?: IWriteOptions): any {
     return null;
   }
 }

--- a/src/editor-kernel/inode/helper.ts
+++ b/src/editor-kernel/inode/helper.ts
@@ -4,19 +4,20 @@ import { IParagraphNode } from './paragraph-node';
 import { IRootNode } from './root-node';
 import { ITextNode } from './text-node';
 
-const BaseContent: INode = {
+const BaseContent = {
   direction: 'ltr',
   format: '',
   indent: 0,
+  type: '',
   version: 1,
 };
 
 export const INodeHelper = {
-  appendChild(parent: IElementNode, child: INode): void {
+  appendChild(parent: IElementNode, ...child: INode[]): void {
     if (!parent.children) {
       parent.children = [];
     }
-    parent.children.push(child);
+    parent.children.push(...child);
   },
 
   createParagraph(attrs: Record<string, unknown> = {}): IParagraphNode {
@@ -49,5 +50,17 @@ export const INodeHelper = {
       text,
       type: 'text',
     };
+  },
+
+  isParagraphNode(node: INode): node is IParagraphNode {
+    return node.type === 'paragraph';
+  },
+
+  isRootNode(node: INode): node is IRootNode {
+    return node.type === 'root';
+  },
+
+  isTextNode(node: INode): node is ITextNode {
+    return node.type === 'text';
   },
 };

--- a/src/editor-kernel/inode/i-element-node.ts
+++ b/src/editor-kernel/inode/i-element-node.ts
@@ -1,6 +1,3 @@
-import { INode } from './i-node';
+import { SerializedElementNode } from 'lexical';
 
-export interface IElementNode extends INode {
-  children: INode[];
-  type: string;
-}
+export type IElementNode = SerializedElementNode;

--- a/src/editor-kernel/inode/i-node.ts
+++ b/src/editor-kernel/inode/i-node.ts
@@ -1,6 +1,3 @@
-export interface INode {
-  direction: 'ltr' | 'rtl';
-  format: string;
-  indent: number;
-  version: number;
-}
+import type { SerializedLexicalNode } from 'lexical';
+
+export type INode = SerializedLexicalNode;

--- a/src/editor-kernel/inode/root-node.ts
+++ b/src/editor-kernel/inode/root-node.ts
@@ -1,8 +1,6 @@
-import { IElementNode } from './i-element-node';
+import { SerializedRootNode } from 'lexical';
 
 /**
  * Root node
  */
-export interface IRootNode extends IElementNode {
-  type: 'root';
-}
+export type IRootNode = SerializedRootNode;

--- a/src/editor-kernel/kernel.ts
+++ b/src/editor-kernel/kernel.ts
@@ -192,6 +192,19 @@ export class Kernel extends EventEmitter implements IEditorKernel {
     return datasource.write(this.editor);
   }
 
+  getSelectionDocument(type: string): unknown | null {
+    const datasource = this.dataTypeMap.get(type);
+    if (!datasource) {
+      throw new Error(`DataSource for type "${type}" is not registered.`);
+    }
+    if (!this.editor) {
+      throw new Error(`Editor is not initialized.`);
+    }
+    return datasource.write(this.editor, {
+      selection: true,
+    });
+  }
+
   registerDecorator(
     name: string,
     decorator: (_node: DecoratorNode<any>, _editor: LexicalEditor) => any,

--- a/src/plugins/codeblock/plugin/index.ts
+++ b/src/plugins/codeblock/plugin/index.ts
@@ -5,7 +5,7 @@ import {
   CodeHighlightNode,
   CodeNode,
 } from '@lexical/code';
-import { LexicalEditor, TabNode } from 'lexical';
+import { DOMConversionOutput, LexicalEditor, TabNode } from 'lexical';
 
 import { KernelPlugin } from '@/editor-kernel/plugin';
 import { IMarkdownShortCutService } from '@/plugins/markdown';
@@ -15,6 +15,31 @@ import { CustomShikiTokenizer, registerCodeCommand } from '../command';
 import { getCodeLanguageByInput } from '../utils/language';
 import { registerCodeHighlighting, toCodeTheme } from './CodeHighlighterShiki';
 import { AllColorReplacements } from './FacadeShiki';
+
+const origin = CodeNode.importDOM;
+
+const LANGUAGE_DATA_ATTRIBUTE = 'data-language';
+const MAX_LENGTH = 8000;
+
+function $convertPreElement(domNode: HTMLElement): DOMConversionOutput {
+  const language = domNode.getAttribute(LANGUAGE_DATA_ATTRIBUTE);
+  if (domNode.innerHTML.length > MAX_LENGTH) {
+    return { node: null };
+  }
+  return { node: $createCodeNode(language) };
+}
+
+CodeNode.importDOM = () => {
+  const node = origin();
+  if (node) {
+    node.pre = () => ({
+      conversion: $convertPreElement,
+      priority: 0,
+    });
+  }
+  // Custom logic for handling imported DOM
+  return node;
+};
 
 export interface CodeblockPluginOptions {
   /** Color replacements configuration for customizing theme colors */

--- a/src/plugins/common/data-source/json-data-source.ts
+++ b/src/plugins/common/data-source/json-data-source.ts
@@ -1,13 +1,145 @@
-import { LexicalEditor } from 'lexical';
+/* eslint-disable unicorn/no-for-loop */
+import { $isTableSelection } from '@lexical/table';
+import {
+  $getCharacterOffsets,
+  $getNodeByKey,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
+  LexicalEditor,
+  SerializedElementNode,
+  SerializedLexicalNode,
+} from 'lexical';
 
 import { DataSource } from '@/editor-kernel';
+import { IWriteOptions } from '@/editor-kernel/data-source';
 
 export default class JSONDataSource extends DataSource {
   read(editor: LexicalEditor, data: any) {
     editor.setEditorState(editor.parseEditorState(data));
   }
 
-  write(editor: LexicalEditor): any {
+  write(editor: LexicalEditor, options?: IWriteOptions): any {
+    if (options?.selection) {
+      return editor.read(() => {
+        const selection = $getSelection();
+        if (!selection) {
+          return null;
+        }
+        if ($isRangeSelection(selection)) {
+          const selectedNodes = selection.getNodes();
+          const selectedNodesLength = selectedNodes.length;
+          const lastIndex = selectedNodesLength - 1;
+          const anchor = selection.anchor;
+          const focus = selection.focus;
+          const isBefore = anchor.isBefore(focus);
+          const firstNode = selectedNodes[0];
+          const lastNode = selectedNodes[lastIndex];
+          const [anchorOffset, focusOffset] = $getCharacterOffsets(selection);
+
+          let lastElement: Array<SerializedElementNode<SerializedLexicalNode> & { $key: string }> =
+            [];
+
+          const rootNodes: Array<SerializedLexicalNode & { $key: string }> = [];
+          for (let i = 0; i < selectedNodes.length; i++) {
+            const node = selectedNodes[i];
+            if ($isElementNode(node)) {
+              const sNode = {
+                ...node.exportJSON(),
+                $key: node.getKey(),
+              };
+              for (let i = 0; i < rootNodes.length; i++) {
+                const child = rootNodes[i];
+                const childNode = $getNodeByKey(child.$key)!;
+                if (node.isParentOf(childNode)) {
+                  sNode.children.push(child);
+                  rootNodes.splice(i, 1);
+                  i--;
+                }
+              }
+              let hasPush = false;
+              for (let i = lastElement.length - 1; i >= 0; i--) {
+                if ($getNodeByKey(lastElement[i].$key)?.isParentOf(node)) {
+                  lastElement[i].children.push(sNode);
+                  hasPush = true;
+                  break;
+                } else {
+                  lastElement.pop();
+                }
+              }
+              if (!hasPush) {
+                rootNodes.push(sNode);
+              }
+              lastElement.push(sNode);
+            } else if ($isTextNode(node)) {
+              const sNode = {
+                ...node.exportJSON(),
+                $key: node.getKey(),
+              };
+              if (node === firstNode) {
+                if (node === lastNode) {
+                  if (
+                    anchor.type !== 'element' ||
+                    focus.type !== 'element' ||
+                    focus.offset === anchor.offset
+                  ) {
+                    sNode.text =
+                      anchorOffset < focusOffset
+                        ? sNode.text.slice(anchorOffset, focusOffset)
+                        : sNode.text.slice(focusOffset, anchorOffset);
+                  }
+                } else {
+                  sNode.text = isBefore
+                    ? sNode.text.slice(anchorOffset)
+                    : sNode.text.slice(focusOffset);
+                }
+              } else if (node === lastNode) {
+                sNode.text = isBefore
+                  ? sNode.text.slice(0, focusOffset)
+                  : sNode.text.slice(0, anchorOffset);
+              }
+              let hasPush = false;
+              for (let i = lastElement.length - 1; i >= 0; i--) {
+                if ($getNodeByKey(lastElement[i].$key)?.isParentOf(node)) {
+                  lastElement[i].children.push(sNode);
+                  hasPush = true;
+                  break;
+                } else {
+                  lastElement.pop();
+                }
+              }
+              if (!hasPush) {
+                rootNodes.push(sNode);
+              }
+            } else {
+              const sNode = {
+                ...node.exportJSON(),
+                $key: node.getKey(),
+              };
+              let hasPush = false;
+              for (let i = lastElement.length - 1; i >= 0; i--) {
+                if ($getNodeByKey(lastElement[i].$key)?.isParentOf(node)) {
+                  lastElement[i].children.push(sNode);
+                  hasPush = true;
+                  break;
+                } else {
+                  lastElement.pop();
+                }
+              }
+              if (!hasPush) {
+                rootNodes.push(sNode);
+              }
+            }
+          }
+
+          return rootNodes;
+        } else if ($isTableSelection(selection)) {
+          // todo
+        }
+        return selection.getNodes().map((node) => node.exportJSON());
+      });
+    }
     return editor.getEditorState().toJSON();
   }
 }

--- a/src/plugins/common/data-source/text-data-source.ts
+++ b/src/plugins/common/data-source/text-data-source.ts
@@ -1,6 +1,7 @@
-import { $getRoot, LexicalEditor } from 'lexical';
+import { $getRoot, $getSelection, LexicalEditor } from 'lexical';
 
 import { DataSource } from '@/editor-kernel';
+import { IWriteOptions } from '@/editor-kernel/data-source';
 import { INodeHelper } from '@/editor-kernel/inode/helper';
 
 export default class TextDataSource extends DataSource {
@@ -22,7 +23,13 @@ export default class TextDataSource extends DataSource {
     editor.setEditorState(editor.parseEditorState({ root: rootNode } as any));
   }
 
-  write(editor: LexicalEditor): any {
+  write(editor: LexicalEditor, options?: IWriteOptions): any {
+    if (options?.selection) {
+      return editor.read(() => {
+        const selection = $getSelection();
+        return selection ? selection.getTextContent() : null;
+      });
+    }
     return editor.getEditorState().read(() => {
       return $getRoot().getTextContent();
     });

--- a/src/plugins/markdown/data-source/markdown-data-source.ts
+++ b/src/plugins/markdown/data-source/markdown-data-source.ts
@@ -1,6 +1,23 @@
-import { $getRoot, $isElementNode, LexicalEditor, LexicalNode } from 'lexical';
+/* eslint-disable unicorn/no-for-loop */
+import { $isTableSelection } from '@lexical/table';
+import {
+  $getCharacterOffsets,
+  $getNodeByKey,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isRangeSelection,
+  $isTextNode,
+  ElementNode,
+  LexicalEditor,
+  LexicalNode,
+  SerializedElementNode,
+  SerializedLexicalNode,
+} from 'lexical';
 
 import { DataSource } from '@/editor-kernel';
+import { IWriteOptions } from '@/editor-kernel/data-source';
+import { INodeHelper } from '@/editor-kernel/inode/helper';
 
 import { MarkdownShortCutService } from '../service/shortcut';
 import { MarkdownWriterContext } from './markdown-writer-context';
@@ -17,23 +34,179 @@ export default class MarkdownDataSource extends DataSource {
     throw new Error('MarkdownDataSource not implemented yet!');
   }
 
-  write(editor: LexicalEditor): any {
+  write(editor: LexicalEditor, options?: IWriteOptions): any {
+    const processChild = (parentCtx: MarkdownWriterContext, child: LexicalNode) => {
+      const writer = this.markdownService.markdownWriters[child.getType()];
+      let currentCtx = parentCtx;
+      if ($isElementNode(child)) {
+        currentCtx = currentCtx.newChild();
+      }
+      if (writer) {
+        writer(currentCtx, child);
+      }
+      if ($isElementNode(child)) {
+        child.getChildren().forEach((child) => processChild(currentCtx, child));
+      }
+    };
+
+    if (options?.selection) {
+      return editor.read(() => {
+        const selection = $getSelection();
+        if (!selection) {
+          return null;
+        }
+        const selectedNodes = selection.getNodes();
+        if ($isRangeSelection(selection)) {
+          const selectedNodesLength = selectedNodes.length;
+          const lastIndex = selectedNodesLength - 1;
+          const anchor = selection.anchor;
+          const focus = selection.focus;
+          const isBefore = anchor.isBefore(focus);
+          const firstNode = selectedNodes[0];
+          const lastNode = selectedNodes[lastIndex];
+          const [anchorOffset, focusOffset] = $getCharacterOffsets(selection);
+
+          let lastElement: Array<SerializedElementNode<SerializedLexicalNode> & { $key: string }> =
+            [];
+          const rootNodes: Array<SerializedLexicalNode & { $key: string }> = [];
+
+          for (let i = 0; i < selectedNodes.length; i++) {
+            const node = selectedNodes[i];
+            if ($isElementNode(node)) {
+              const sNode = {
+                ...node.exportJSON(),
+                $key: node.getKey(),
+              };
+              for (let i = 0; i < rootNodes.length; i++) {
+                const child = rootNodes[i];
+                const childNode = $getNodeByKey(child.$key)!;
+                if (node.isParentOf(childNode)) {
+                  sNode.children.push(child);
+                  rootNodes.splice(i, 1);
+                  i--;
+                }
+              }
+              let hasPush = false;
+              for (let i = lastElement.length - 1; i >= 0; i--) {
+                if ($getNodeByKey(lastElement[i].$key)?.isParentOf(node)) {
+                  lastElement[i].children.push(sNode);
+                  hasPush = true;
+                  break;
+                } else {
+                  lastElement.pop();
+                }
+              }
+              if (!hasPush) {
+                rootNodes.push(sNode);
+              }
+              lastElement.push(sNode);
+            } else if ($isTextNode(node)) {
+              const sNode = {
+                ...node.exportJSON(),
+                $key: node.getKey(),
+              };
+              if (node === firstNode) {
+                if (node === lastNode) {
+                  if (
+                    anchor.type !== 'element' ||
+                    focus.type !== 'element' ||
+                    focus.offset === anchor.offset
+                  ) {
+                    sNode.text =
+                      anchorOffset < focusOffset
+                        ? sNode.text.slice(anchorOffset, focusOffset)
+                        : sNode.text.slice(focusOffset, anchorOffset);
+                  }
+                } else {
+                  sNode.text = isBefore
+                    ? sNode.text.slice(anchorOffset)
+                    : sNode.text.slice(focusOffset);
+                }
+              } else if (node === lastNode) {
+                sNode.text = isBefore
+                  ? sNode.text.slice(0, focusOffset)
+                  : sNode.text.slice(0, anchorOffset);
+              }
+              let hasPush = false;
+              for (let i = lastElement.length - 1; i >= 0; i--) {
+                if ($getNodeByKey(lastElement[i].$key)?.isParentOf(node)) {
+                  lastElement[i].children.push(sNode);
+                  hasPush = true;
+                  break;
+                } else {
+                  lastElement.pop();
+                }
+              }
+              if (!hasPush) {
+                rootNodes.push(sNode);
+              }
+            } else {
+              const sNode = {
+                ...node.exportJSON(),
+                $key: node.getKey(),
+              };
+              let hasPush = false;
+              for (let i = lastElement.length - 1; i >= 0; i--) {
+                if ($getNodeByKey(lastElement[i].$key)?.isParentOf(node)) {
+                  lastElement[i].children.push(sNode);
+                  hasPush = true;
+                  break;
+                } else {
+                  lastElement.pop();
+                }
+              }
+              if (!hasPush) {
+                rootNodes.push(sNode);
+              }
+            }
+          }
+
+          const rootNode = INodeHelper.createRootNode();
+          if (rootNodes.some((node) => INodeHelper.isTextNode(node))) {
+            const p = INodeHelper.createParagraph();
+            INodeHelper.appendChild(p, ...rootNodes);
+            INodeHelper.appendChild(rootNode, p);
+          } else {
+            INodeHelper.appendChild(rootNode, ...rootNodes);
+          }
+
+          const editorState = editor.parseEditorState({ root: rootNode });
+
+          const lexicalRootNode = editorState._nodeMap.get('root') as ElementNode;
+          const rootCtx = new MarkdownWriterContext();
+
+          return editorState.read(() => {
+            lexicalRootNode.getChildren().forEach((child) => processChild(rootCtx, child));
+            return rootCtx.toString();
+          });
+        } else if ($isTableSelection(selection)) {
+          // todo
+        }
+
+        const rootNode = INodeHelper.createRootNode();
+        if (selectedNodes.some((node) => node.isInline())) {
+          const p = INodeHelper.createParagraph();
+          INodeHelper.appendChild(p, ...selectedNodes.map((node) => node.exportJSON()));
+          INodeHelper.appendChild(rootNode, p);
+        } else {
+          INodeHelper.appendChild(rootNode, ...selectedNodes.map((node) => node.exportJSON()));
+        }
+
+        const editorState = editor.parseEditorState({ root: rootNode });
+
+        const lexicalRootNode = editorState._nodeMap.get('root') as ElementNode;
+        const rootCtx = new MarkdownWriterContext();
+
+        return editorState.read(() => {
+          lexicalRootNode.getChildren().forEach((child) => processChild(rootCtx, child));
+          return rootCtx.toString();
+        });
+      });
+    }
     return editor.getEditorState().read(() => {
       const rootNode = $getRoot();
       const rootCtx = new MarkdownWriterContext();
-      const processChild = (parentCtx: MarkdownWriterContext, child: LexicalNode) => {
-        const writer = this.markdownService.markdownWriters[child.getType()];
-        let currentCtx = parentCtx;
-        if ($isElementNode(child)) {
-          currentCtx = currentCtx.newChild();
-        }
-        if (writer) {
-          writer(currentCtx, child);
-        }
-        if ($isElementNode(child)) {
-          child.getChildren().forEach((child) => processChild(currentCtx, child));
-        }
-      };
+
       rootNode.getChildren().forEach((child) => processChild(rootCtx, child));
       return rootCtx.toString();
     });

--- a/src/types/kernel.ts
+++ b/src/types/kernel.ts
@@ -68,6 +68,12 @@ export interface IEditor {
    * Get document editor root node
    */
   getRootElement(): HTMLElement | null;
+
+  /**
+   * Get document editor selection content of specified type
+   * @param type
+   */
+  getSelectionDocument(type: string): unknown | null;
   /**
    * Get editor theme
    */
@@ -103,6 +109,7 @@ export interface IEditor {
    * Register multiple editor plugins
    */
   registerPlugins(plugins: Array<IPlugin>): IEditor;
+
   /**
    * Get editor Service, usually provided by plugins to extend certain functionalities
    * @param serviceId


### PR DESCRIPTION
#13 

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

1. 支持 getSelectionDocument
2. 超过一定长度的 pre 不会解析成代码块

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Support selection-based data extraction across data sources, skip oversized <pre> elements during HTML import for code blocks, and improve helper interfaces for node manipulation

New Features:
- Add getSelectionDocument API for retrieving editor selection content in a specified format
- Extend DataSource.write to accept a selection option for partial serialization in Markdown, JSON, and plain text

Enhancements:
- Introduce IWriteOptions interface and update base DataSource signature
- Enhance INodeHelper with variadic appendChild and type guard methods