### PR TITLE
✨ feat: add space after punctuation for markdown <em> o

### DIFF
--- a/src/plugins/common/plugin/index.ts
+++ b/src/plugins/common/plugin/index.ts
@@ -14,7 +14,7 @@ import { $createLineBreakNode, $createParagraphNode, $isTextNode } from 'lexical
 import { LexicalEditor } from 'lexical/LexicalEditor';
 
 import { KernelPlugin } from '@/editor-kernel/plugin';
-import { IMarkdownShortCutService } from '@/plugins/markdown';
+import { IMarkdownShortCutService, isPunctuationChar } from '@/plugins/markdown';
 import { IEditorKernel, IEditorPlugin, IEditorPluginConstructor } from '@/types';
 
 import { registerCommands } from '../command';
@@ -201,10 +201,6 @@ export const CommonPlugin: IEditorPluginConstructor<CommonPluginOptions> = class
       const isStrikethrough = node.hasFormat('strikethrough');
       const isCode = node.hasFormat('code');
 
-      if (isCode || isBold || isStrikethrough || isItalic || isUnderline) {
-        ctx.appendLine(' ');
-      }
-
       if (isCode) {
         ctx.appendLine('`');
       }
@@ -220,7 +216,16 @@ export const CommonPlugin: IEditorPluginConstructor<CommonPluginOptions> = class
       if (isUnderline) {
         ctx.appendLine('<u>');
       }
-      ctx.appendLine(node.getTextContent());
+
+      const textContent = node.getTextContent();
+      const res = textContent.match(/\s+$/);
+      let tailSpace = '';
+      if (res) {
+        tailSpace = res[0];
+      }
+      const append = textContent.trimEnd();
+      const lastChar = append.at(-1);
+      ctx.appendLine(append);
       if (isUnderline) {
         ctx.appendLine('</u>');
       }
@@ -237,7 +242,9 @@ export const CommonPlugin: IEditorPluginConstructor<CommonPluginOptions> = class
         ctx.appendLine('`');
       }
 
-      if (isCode || isBold || isStrikethrough || isItalic || isUnderline) {
+      if (tailSpace) {
+        ctx.appendLine(tailSpace);
+      } else if (lastChar && isPunctuationChar(lastChar)) {
         ctx.appendLine(' ');
       }
     });

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -1,2 +1,3 @@
 export { MarkdownPlugin } from './plugin';
 export { IMarkdownShortCutService } from './service/shortcut';
+export { isPunctuationChar } from './utils';

--- a/src/plugins/markdown/utils/index.ts
+++ b/src/plugins/markdown/utils/index.ts
@@ -68,3 +68,17 @@ export function indexBy<T>(
 
   return index;
 }
+
+let Punctuation = /[!"#$%&'()*+,./:;<=>?@[\\\]^_`{|}~\u00A1\u2010-\u2027-]/;
+try {
+  Punctuation = new RegExp('[\\p{Pc}|\\p{Pd}|\\p{Pe}|\\p{Pf}|\\p{Pi}|\\p{Po}|\\p{Ps}]', 'u');
+} catch {}
+
+/**
+ * Checks if a character is a punctuation character.
+ * @param char The character to check.
+ * @returns True if the character is a punctuation character, false otherwise.
+ */
+export function isPunctuationChar(char: string): boolean {
+  return Punctuation.test(char);
+}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add punctuation detection and adjust CommonPlugin text processing to preserve existing trailing spaces and automatically insert a space after punctuation in formatted markdown output.

New Features:
- Introduce isPunctuationChar utility with Unicode-aware regex to identify punctuation characters
- Export isPunctuationChar from the markdown plugin

Enhancements:
- Refine CommonPlugin to preserve original trailing whitespace on text nodes
- Append a single space only when a formatted node’s last character is punctuation