### PR TITLE
✨ feat: Add registerLastElement function to handle trailing paragraphs

### DIFF
--- a/src/plugins/common/plugin/index.ts
+++ b/src/plugins/common/plugin/index.ts
@@ -23,7 +23,7 @@ import TextDataSource from '../data-source/text-data-source';
 import { patchBreakLine, registerBreakLineClick } from '../node/ElementDOMSlot';
 import { CursorNode, registerCursorNode } from '../node/cursor';
 import { createBlockNode } from '../utils';
-import { registerHeaderBackspace, registerRichKeydown } from './register';
+import { registerHeaderBackspace, registerLastElement, registerRichKeydown } from './register';
 
 patchBreakLine();
 
@@ -266,6 +266,7 @@ export const CommonPlugin: IEditorPluginConstructor<CommonPluginOptions> = class
       registerCommands(editor),
       registerBreakLineClick(editor),
       registerCursorNode(editor),
+      registerLastElement(editor),
     );
   }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

close #22 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add registerLastElement plugin to automatically append a paragraph after trailing code or table nodes and integrate it into CommonPlugin

New Features:
- Introduce registerLastElement to detect when the last editor element is a code or table node and queue the insertion of a trailing paragraph

Enhancements:
- Clarify backspace command comment to specify handling for heading nodes