### PR TITLE
✨ feat: Add node comparison utility and update MathEditor components

### DIFF
--- a/src/editor-kernel/utils.ts
+++ b/src/editor-kernel/utils.ts
@@ -88,3 +88,46 @@ export function getKernelFromEditor(editor: LexicalEditor): IEditorKernel {
   // @ts-expect-error __kernel is injected into the lexical editor instance
   return editor._createEditorArgs?.__kernel || editor._kernel;
 }
+
+/**
+ *
+ * @param nodeA
+ * @param nodeB
+ * @returns
+ */
+export function compareNodeOrder(nodeA: LexicalNode, nodeB: LexicalNode): number {
+  if (nodeA === nodeB) {
+    return 0;
+  }
+  const pathA: LexicalNode[] = [];
+  const pathB: LexicalNode[] = [];
+  let currentA: LexicalNode | null = nodeA;
+  let currentB: LexicalNode | null = nodeB;
+
+  while (currentA) {
+    pathA.unshift(currentA);
+    currentA = currentA.getParent();
+  }
+
+  while (currentB) {
+    pathB.unshift(currentB);
+    currentB = currentB.getParent();
+  }
+
+  const minLength = Math.min(pathA.length, pathB.length);
+
+  for (let i = 0; i < minLength; i++) {
+    if (pathA[i] !== pathB[i]) {
+      const siblings = pathA[i].getParent()?.getChildren() || [];
+      return siblings.indexOf(pathA[i]) - siblings.indexOf(pathB[i]);
+    }
+  }
+
+  // If all nodes in the shorter path are the same, the shorter path's node comes first
+  if (pathA.length !== pathB.length) {
+    return pathA.length - pathB.length;
+  }
+
+  // This case should not happen as we checked for equality at the start
+  return 0;
+}

--- a/src/plugins/common/plugin/register.ts
+++ b/src/plugins/common/plugin/register.ts
@@ -273,7 +273,7 @@ export function registerRichKeydown(
             });
             event.preventDefault();
             return true;
-          } else if (possibleNode) {
+          } else if (possibleNode && possibleNode.getType() !== 'linebreak') {
             possibleNode?.selectEnd();
             event.preventDefault();
             return true;
@@ -330,7 +330,7 @@ export function registerRichKeydown(
             });
             event.preventDefault();
             return true;
-          } else if (possibleNode) {
+          } else if (possibleNode && possibleNode.getType() !== 'linebreak') {
             possibleNode?.selectStart();
             event.preventDefault();
             return true;

--- a/src/plugins/math/react/components/MathEditorContainer.tsx
+++ b/src/plugins/math/react/components/MathEditorContainer.tsx
@@ -27,6 +27,8 @@ const MathEditorContainer = memo<MathEditorContainerProps>(
       return updatePosition({
         callback: () => {
           if (!divRef.current || !mathDOM) return;
+          // 展示的时候聚焦
+          onFocus?.();
           if (!isBlockMode) {
             divRef.current.style.width = '';
             return;

--- a/src/plugins/math/react/components/MathEditorContent.tsx
+++ b/src/plugins/math/react/components/MathEditorContent.tsx
@@ -31,7 +31,7 @@ export interface MathEditorContentProps {
   /** 值变化回调 */
   onValueChange: (value: string) => void;
   /** 是否从前一个位置进入 */
-  prev: boolean;
+  // prev: boolean;
   /** 当前输入值 */
   value: string;
 }
@@ -47,7 +47,7 @@ const MathEditorContent = memo<MathEditorContentProps>(
     onSubmit,
     onValidationChange,
     onValueChange,
-    prev,
+    // prev,
     value,
   }) => {
     const t = useTranslation();
@@ -60,15 +60,15 @@ const MathEditorContent = memo<MathEditorContentProps>(
       focusRef?.(textareaRef.current);
     }, [focusRef]);
 
-    // 聚焦和光标位置处理
-    useEffect(() => {
-      if (textareaRef.current) {
-        textareaRef.current.focus();
-        if (prev) {
-          textareaRef.current.resizableTextArea?.textArea?.setSelectionRange(0, 0);
-        }
-      }
-    }, [prev]);
+    // // 聚焦和光标位置处理
+    // useEffect(() => {
+    //   if (textareaRef.current) {
+    //     textareaRef.current.focus();
+    //     if (prev) {
+    //       textareaRef.current.resizableTextArea?.textArea?.setSelectionRange(0, 0);
+    //     }
+    //   }
+    // }, [prev]);
 
     // 实时验证 LaTeX 语法
     useEffect(() => {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

#32 

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add a utility to compare LexicalNode positions, integrate proper update batching and cursor logic in MathEditor, auto-focus the editor container on open, and refine keydown navigation to ignore linebreak nodes.

New Features:
- Add compareNodeOrder utility to determine ordering of LexicalNodes
- Wrap math node code updates in lexicalEditor.update for proper state batching
- Use compareNodeOrder in MathEditor to set cursor-relative prev state
- Auto-focus MathEditorContainer on display via onFocus callback

Bug Fixes:
- Prevent selecting linebreak nodes in rich text keydown navigation handlers

Enhancements:
- Remove unused prev prop and related focus effect from MathEditorContent