### PR TITLE
🐛 fix: Prevent cursor updates during composition and ensure mentions …

### DIFF
--- a/src/plugins/common/node/cursor.ts
+++ b/src/plugins/common/node/cursor.ts
@@ -123,6 +123,10 @@ export function registerCursorNode(editor: LexicalEditor) {
     editor.registerUpdateListener(() => {
       editor.read(() => {
         const selection = $getSelection();
+        const isComposing = editor.isComposing();
+        if (isComposing) {
+          return false;
+        }
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
           return false;
         }

--- a/src/plugins/mention/command/index.ts
+++ b/src/plugins/mention/command/index.ts
@@ -1,7 +1,6 @@
 import { $wrapNodeInElement } from '@lexical/utils';
 import {
   $createParagraphNode,
-  $createTextNode,
   $insertNodes,
   $isRootOrShadowRoot,
   COMMAND_PRIORITY_HIGH,
@@ -26,12 +25,8 @@ export function registerMentionCommand(editor: LexicalEditor) {
         $insertNodes([mentionNode]);
         // Ensure mention is inside a paragraph when inserted at root
         if ($isRootOrShadowRoot(mentionNode.getParentOrThrow())) {
-          $wrapNodeInElement(mentionNode, $createParagraphNode);
+          $wrapNodeInElement(mentionNode, $createParagraphNode).selectEnd();
         }
-        // Insert a trailing text node and move caret into it to enable IME input
-        const trailingText = $createTextNode('\u200B');
-        mentionNode.insertAfter(trailingText);
-        trailingText.selectEnd();
       });
       return true;
     },


### PR DESCRIPTION
…are wrapped in paragraphs

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

修复 cursor 在输入法下表现异常问题

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Prevent cursor interruptions during IME composition and improve mention insertion by wrapping at-root mentions in paragraphs and moving the caret appropriately

Bug Fixes:
- Skip cursor update callbacks while the editor is composing (e.g., during IME input)
- Wrap mention nodes inserted at the root in paragraph elements to maintain valid structure

Enhancements:
- Select the end of the newly created paragraph after inserting a mention and remove the trailing zero-width space workaround