### PR TITLE
✨ feat: Add markdown reader support for mention plugin and enhance ma…

### DIFF
--- a/src/plugins/common/plugin/__test__/markdown.test.ts
+++ b/src/plugins/common/plugin/__test__/markdown.test.ts
@@ -1,0 +1,38 @@
+import { IS_UNDERLINE } from 'lexical';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+import { MarkdownPlugin } from '@/plugins/markdown';
+import { IEditor } from '@/types';
+
+describe('Common Plugin Tests', () => {
+  let kernel: IEditor;
+
+  beforeEach(() => {
+    kernel = Editor.createEditor();
+    kernel.registerPlugins([CommonPlugin, MarkdownPlugin]);
+  });
+
+  it('should markdown reader work', () => {
+    kernel.setRootElement(document.createElement('div'));
+    kernel.setDocument('markdown', 'this is <ins>underline</ins> and this is <u>underline2</u>');
+    const { root } = kernel.getDocument('json') as any;
+
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].type).toBe('paragraph');
+    expect(root.children[0].children.length).toBe(4);
+
+    expect(root.children[0].children[0].text).toBe('this is ');
+    expect(root.children[0].children[0].format).toBe(0);
+
+    expect(root.children[0].children[1].text).toBe('underline');
+    expect(root.children[0].children[1].format & IS_UNDERLINE).toBe(IS_UNDERLINE);
+
+    expect(root.children[0].children[2].text).toBe(' and this is ');
+    expect(root.children[0].children[2].format).toBe(0);
+
+    expect(root.children[0].children[3].text).toBe('underline2');
+    expect(root.children[0].children[3].format & IS_UNDERLINE).toBe(IS_UNDERLINE);
+  });
+});

--- a/src/plugins/common/plugin/__test__/markdown.test.ts
+++ b/src/plugins/common/plugin/__test__/markdown.test.ts
@@ -50,8 +50,6 @@ describe('Common Plugin Tests', () => {
 
     expect(root.children[0].children[1].text).toBe('strong');
     expect(root.children[0].children[1].format & IS_UNDERLINE).toBe(IS_UNDERLINE);
-
-    expect(root.children[0].children[1].text).toBe('strong');
     expect(root.children[0].children[1].format & IS_BOLD).toBe(IS_BOLD);
   });
 });

--- a/src/plugins/common/plugin/__test__/markdown.test.ts
+++ b/src/plugins/common/plugin/__test__/markdown.test.ts
@@ -1,4 +1,4 @@
-import { IS_UNDERLINE } from 'lexical';
+import { IS_BOLD, IS_UNDERLINE } from 'lexical';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import Editor from '@/editor-kernel';
@@ -34,5 +34,24 @@ describe('Common Plugin Tests', () => {
 
     expect(root.children[0].children[3].text).toBe('underline2');
     expect(root.children[0].children[3].format & IS_UNDERLINE).toBe(IS_UNDERLINE);
+  });
+
+  it('should markdown html mix markdown work', () => {
+    kernel.setRootElement(document.createElement('div'));
+    kernel.setDocument('markdown', 'this is <ins>**strong**</ins>');
+    const { root } = kernel.getDocument('json') as any;
+
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].type).toBe('paragraph');
+    expect(root.children[0].children.length).toBe(2);
+
+    expect(root.children[0].children[0].text).toBe('this is ');
+    expect(root.children[0].children[0].format).toBe(0);
+
+    expect(root.children[0].children[1].text).toBe('strong');
+    expect(root.children[0].children[1].format & IS_UNDERLINE).toBe(IS_UNDERLINE);
+
+    expect(root.children[0].children[1].text).toBe('strong');
+    expect(root.children[0].children[1].format & IS_BOLD).toBe(IS_BOLD);
   });
 });

--- a/src/plugins/common/plugin/mdReader.ts
+++ b/src/plugins/common/plugin/mdReader.ts
@@ -1,4 +1,11 @@
-import { IS_BOLD, IS_ITALIC, IS_STRIKETHROUGH, IS_SUBSCRIPT, IS_SUPERSCRIPT } from 'lexical';
+import {
+  IS_BOLD,
+  IS_ITALIC,
+  IS_STRIKETHROUGH,
+  IS_SUBSCRIPT,
+  IS_SUPERSCRIPT,
+  IS_UNDERLINE,
+} from 'lexical';
 
 import type { INode } from '@/editor-kernel/inode';
 import { INodeHelper } from '@/editor-kernel/inode/helper';
@@ -61,5 +68,31 @@ export function registerMDReader(markdownService: IMarkdownShortCutService) {
       }
       return child;
     });
+  });
+
+  markdownService.registerMarkdownReader('html', (node, children) => {
+    if (['<ins>', '<u>'].includes(node.value.toLocaleLowerCase())) {
+      return children.map((child) => {
+        if (INodeHelper.isTextNode(child)) {
+          child.format = (child.format || 0) | IS_UNDERLINE;
+        }
+        return child;
+      });
+    } else if (['<em>'].includes(node.value.toLocaleLowerCase())) {
+      return children.map((child) => {
+        if (INodeHelper.isTextNode(child)) {
+          child.format = (child.format || 0) | IS_ITALIC;
+        }
+        return child;
+      });
+    } else if (['<strong>'].includes(node.value.toLocaleLowerCase())) {
+      return children.map((child) => {
+        if (INodeHelper.isTextNode(child)) {
+          child.format = (child.format || 0) | IS_BOLD;
+        }
+        return child;
+      });
+    }
+    return false;
   });
 }

--- a/src/plugins/markdown/data-source/markdown/parse.test.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.test.ts
@@ -55,4 +55,33 @@ describe('Markdown to Lexical Conversion', () => {
     // @ts-expect-error not error
     expect(lexical.children[0]?.children?.[1]?.format).toBe(1);
   });
+
+  it('should work html mix markdown', () => {
+    const markdown = 'This is a <b>**bold**</b> text.';
+    const lexical = parseMarkdownToLexical(markdown, {
+      html: (node, children) => {
+        if (node.value === '<b>') {
+          return children;
+        }
+        return false;
+      },
+      strong: (node: Strong, children) => {
+        return children.map((child) => {
+          if (INodeHelper.isTextNode(child)) {
+            child.format = (child.format || 0) | IS_BOLD;
+          }
+          return child;
+        });
+      },
+    });
+
+    expect(lexical.children.length).toEqual(1);
+    expect(lexical.children[0].type).toEqual('paragraph');
+    // @ts-expect-error not error
+    expect(lexical.children[0].children.length).toEqual(3);
+    // @ts-expect-error not error
+    expect(INodeHelper.isTextNode(lexical.children[0]?.children?.[1])).toBe(true);
+    // @ts-expect-error not error
+    expect(lexical.children[0]?.children?.[1]?.format).toBe(1);
+  });
 });

--- a/src/plugins/markdown/data-source/markdown/parse.test.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.test.ts
@@ -29,4 +29,30 @@ describe('Markdown to Lexical Conversion', () => {
     // @ts-expect-error not error
     expect(lexical.children[0]?.children?.[1]?.format).toBe(1);
   });
+
+  it('should work html node', () => {
+    const markdown = 'This is a <b>bold</b> text.';
+    const lexical = parseMarkdownToLexical(markdown, {
+      html: (node, children) => {
+        if (node.value === '<b>') {
+          return children.map((child) => {
+            if (INodeHelper.isTextNode(child)) {
+              child.format = (child.format || 0) | IS_BOLD;
+            }
+            return child;
+          });
+        }
+        return false;
+      },
+    });
+
+    expect(lexical.children.length).toEqual(1);
+    expect(lexical.children[0].type).toEqual('paragraph');
+    // @ts-expect-error not error
+    expect(lexical.children[0].children.length).toEqual(3);
+    // @ts-expect-error not error
+    expect(INodeHelper.isTextNode(lexical.children[0]?.children?.[1])).toBe(true);
+    // @ts-expect-error not error
+    expect(lexical.children[0]?.children?.[1]?.format).toBe(1);
+  });
 });

--- a/src/plugins/markdown/index.ts
+++ b/src/plugins/markdown/index.ts
@@ -1,3 +1,9 @@
 export { MarkdownPlugin } from './plugin';
-export { IMarkdownShortCutService } from './service/shortcut';
+export type { MARKDOWN_READER_LEVEL } from './service/shortcut';
+export {
+  IMarkdownShortCutService,
+  MARKDOWN_READER_LEVEL_HIGH,
+  MARKDOWN_READER_LEVEL_NORMAL,
+  MARKDOWN_WRITER_LEVEL_MAX,
+} from './service/shortcut';
 export { isPunctuationChar } from './utils';

--- a/src/plugins/markdown/service/shortcut.ts
+++ b/src/plugins/markdown/service/shortcut.ts
@@ -257,6 +257,8 @@ export class MarkdownShortCutService implements IMarkdownShortCutService {
       this._markdownReaders[level][type] = [];
     }
 
-    this._markdownReaders[level][type].push(reader);
+    if (this._markdownReaders[level]) {
+      this._markdownReaders[level][type].push(reader);
+    }
   }
 }

--- a/src/plugins/markdown/service/shortcut.ts
+++ b/src/plugins/markdown/service/shortcut.ts
@@ -1,16 +1,16 @@
 /* eslint-disable no-redeclare */
 /* eslint-disable @typescript-eslint/no-redeclare */
-import {
-  ElementNode,
-  LexicalNode,
-  TextNode,
-} from 'lexical';
+import { ElementNode, LexicalNode, TextNode } from 'lexical';
 
 import { genServiceId } from '@/editor-kernel';
 import type { IEditorKernel, IServiceID } from '@/types/kernel';
 import { createDebugLogger } from '@/utils/debug';
 
-import type { TransformerRecord } from '../data-source/markdown/parse';
+import type {
+  MarkdownReaderFunc,
+  TransformerRecord,
+  TransfromerRecordArray,
+} from '../data-source/markdown/parse';
 import { indexBy } from '../utils';
 import type {
   ElementTransformer,
@@ -49,13 +49,23 @@ export interface IMarkdownWriterContext {
   wrap: (before: string, after: string) => void;
 }
 
+export const MARKDOWN_WRITER_LEVEL_MAX = 0;
+export const MARKDOWN_READER_LEVEL_HIGH = 1;
+export const MARKDOWN_READER_LEVEL_NORMAL = 2;
+
+export type MARKDOWN_READER_LEVEL =
+  | typeof MARKDOWN_READER_LEVEL_HIGH
+  | typeof MARKDOWN_READER_LEVEL_NORMAL
+  | typeof MARKDOWN_WRITER_LEVEL_MAX;
+
 export interface IMarkdownShortCutService {
   /**
    * Register Markdown reader
    */
   registerMarkdownReader<K extends keyof TransformerRecord>(
     type: K,
-    reader: TransformerRecord[K],
+    reader: MarkdownReaderFunc<K>,
+    level?: MARKDOWN_READER_LEVEL,
   ): void;
 
   registerMarkdownShortCut(transformer: Transformer): void;
@@ -85,7 +95,11 @@ export class MarkdownShortCutService implements IMarkdownShortCutService {
     (_ctx: IMarkdownWriterContext, _node: LexicalNode) => boolean | void
   > = {};
 
-  private _markdownReaders: TransformerRecord = {};
+  private _markdownReaders: [
+    TransfromerRecordArray,
+    TransfromerRecordArray,
+    TransfromerRecordArray,
+  ] = [{}, {}, {}];
 
   constructor(private kernel?: IEditorKernel) {}
 
@@ -94,7 +108,21 @@ export class MarkdownShortCutService implements IMarkdownShortCutService {
   }
 
   get markdownReaders() {
-    return this._markdownReaders;
+    return this._markdownReaders.reduce(
+      (acc: TransfromerRecordArray, curr: TransfromerRecordArray) => {
+        // @ts-expect-error not error
+        Object.keys(curr).forEach((key: keyof TransfromerRecordArray) => {
+          if (!acc[key]) {
+            acc[key] = [];
+          }
+          const existing = acc[key] as Array<MarkdownReaderFunc<typeof key>>;
+          const adding = curr[key];
+          existing.push(...(adding as Array<MarkdownReaderFunc<typeof key>>));
+        });
+        return acc;
+      },
+      {} as TransfromerRecordArray,
+    );
   }
 
   private _textFormatTransformersByTrigger: Readonly<
@@ -222,17 +250,13 @@ export class MarkdownShortCutService implements IMarkdownShortCutService {
 
   registerMarkdownReader<K extends keyof TransformerRecord>(
     type: K,
-    reader: TransformerRecord[K],
+    reader: MarkdownReaderFunc<K>,
+    level: MARKDOWN_READER_LEVEL = MARKDOWN_READER_LEVEL_NORMAL,
   ): void {
-    if (!this._markdownReaders[type]) {
-      this._markdownReaders[type] = reader;
-      return;
+    if (!this._markdownReaders[level][type]) {
+      this._markdownReaders[level][type] = [];
     }
-    if (this.kernel?.isHotReloadMode()) {
-      this.logger.warn(`🔄 Hot reload: markdown reader "${type}"`);
-      this._markdownReaders[type] = reader;
-      return;
-    }
-    throw new Error(`Markdown reader for type "${type}" is already registered.`);
+
+    this._markdownReaders[level][type].push(reader);
   }
 }

--- a/src/plugins/markdown/service/shortcut.ts
+++ b/src/plugins/markdown/service/shortcut.ts
@@ -258,7 +258,7 @@ export class MarkdownShortCutService implements IMarkdownShortCutService {
     }
 
     if (this._markdownReaders[level]) {
-      this._markdownReaders[level][type].push(reader);
+      this._markdownReaders[level][type]?.push(reader);
     }
   }
 }

--- a/src/plugins/mention/index.ts
+++ b/src/plugins/mention/index.ts
@@ -1,3 +1,4 @@
 export { INSERT_MENTION_COMMAND } from './command';
+export type { SerializedMentionNode } from './node/MentionNode';
 export * from './plugin';
 export * from './react';

--- a/src/plugins/mention/plugin/__tests__/mention.test.ts
+++ b/src/plugins/mention/plugin/__tests__/mention.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+import { MarkdownPlugin } from '@/plugins/markdown';
+import { IEditor } from '@/types';
+
+import { MentionPlugin } from '..';
+
+describe('Mention Plugin Tests', () => {
+  let kernel: IEditor;
+
+  beforeEach(() => {
+    kernel = Editor.createEditor();
+    kernel.registerPlugins([CommonPlugin, MarkdownPlugin]);
+  });
+
+  it('should markdown reader work', () => {
+    kernel.registerPlugin(MentionPlugin, {
+      decorator: () => {
+        return null;
+      },
+      markdownReader: (node, children) => {
+        if (node.value === '<mention>') {
+          const text = children
+            .map((child) => {
+              if (child.type === 'text') {
+                // @ts-expect-error not error
+                return child.text;
+              }
+              return '';
+            })
+            .join('');
+          return {
+            type: 'mention',
+            version: 1,
+            label: text.split('[')[0],
+            metadata: {
+              id: text.split('[')[1]?.replace(']', '') || '',
+            },
+          };
+        }
+        return false;
+      },
+    });
+
+    kernel.setRootElement(document.createElement('div'));
+    kernel.setDocument('markdown', '<mention>前端研发专家[bot1]</mention>');
+    const { root } = kernel.getDocument('json') as any;
+
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].type).toBe('paragraph');
+    expect(root.children[0].children.length).toBe(1);
+
+    const mention = root.children[0].children[0];
+    expect(mention.type).toBe('mention');
+    expect(mention.label).toBe('前端研发专家');
+    expect(mention.metadata.id).toBe('bot1');
+  });
+});

--- a/src/plugins/mention/plugin/index.ts
+++ b/src/plugins/mention/plugin/index.ts
@@ -1,16 +1,19 @@
 import { DecoratorNode, LexicalEditor } from 'lexical';
+import { Html } from 'mdast';
 
+import { INode } from '@/editor-kernel/inode';
 import { KernelPlugin } from '@/editor-kernel/plugin';
-import { IMarkdownShortCutService } from '@/plugins/markdown';
+import { IMarkdownShortCutService, MARKDOWN_READER_LEVEL_HIGH } from '@/plugins/markdown';
 import type { IEditorKernel, IEditorPlugin, IEditorPluginConstructor } from '@/types';
 
 import { registerMentionCommand } from '../command';
-import { $isMentionNode, MentionNode } from '../node/MentionNode';
+import { $isMentionNode, MentionNode, SerializedMentionNode } from '../node/MentionNode';
 import { registerMentionNodeSelectionObserver } from './register';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface MentionPluginOptions {
   decorator: (node: MentionNode, editor: LexicalEditor) => any;
+  markdownReader?: (node: Html, children: INode[]) => SerializedMentionNode | null | false;
   markdownWriter?: (file: MentionNode) => string;
   theme?: {
     mention?: string;
@@ -40,21 +43,39 @@ export const MentionPlugin: IEditorPluginConstructor<MentionPluginOptions> = cla
         return config?.decorator ? config.decorator(node as MentionNode, editor) : null;
       },
     );
-    kernel
-      .requireService(IMarkdownShortCutService)
-      ?.registerMarkdownWriter(MentionNode.getType(), (ctx, node) => {
-        if ($isMentionNode(node)) {
-          if (config?.markdownWriter) {
-            ctx.appendLine(config.markdownWriter(node));
-            return;
-          }
-          ctx.appendLine(`${node.label}`);
-        }
-      });
   }
 
   onInit(editor: LexicalEditor): void {
     this.register(registerMentionCommand(editor));
     this.register(registerMentionNodeSelectionObserver(editor));
+
+    this.registerMarkdown();
+  }
+
+  private registerMarkdown() {
+    this.kernel
+      .requireService(IMarkdownShortCutService)
+      ?.registerMarkdownWriter(MentionNode.getType(), (ctx, node) => {
+        if ($isMentionNode(node)) {
+          if (this.config?.markdownWriter) {
+            ctx.appendLine(this.config.markdownWriter(node));
+            return;
+          }
+          ctx.appendLine(`${node.label}`);
+        }
+      });
+
+    if (this.config?.markdownReader) {
+      this.kernel.requireService(IMarkdownShortCutService)?.registerMarkdownReader(
+        'html',
+        (node, children) => {
+          return this.config?.markdownReader
+            ? this.config.markdownReader(node, children) || false
+            : false;
+          // return this.config?.markdownReader ? this.config.markdownReader(node, children) || false : false;
+        },
+        MARKDOWN_READER_LEVEL_HIGH,
+      );
+    }
   }
 };


### PR DESCRIPTION
…rkdown parsing

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

markdown 数据源支持注册 HTML reader

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Add HTML reader support to markdown parser and extend markdown shortcut service to register multiple reader functions with priority levels, enabling plugins like MentionPlugin to provide custom markdownReader and markdownWriter. Refactor default reader registration and add unit tests for HTML node parsing.

New Features:
- Support HTML node parsing in markdown-to-lexical conversion via MarkdownContext and custom HTML reader functions
- Enable registering multiple markdown readers per node type with configurable priority levels in MarkdownShortCutService
- Allow MentionPlugin to register a markdownReader for HTML mention nodes alongside existing markdownWriter

Enhancements:
- Refactor markdown parser to register default readers for root, paragraph, and heading nodes and uniformly handle reader function arrays
- Implement merging logic in markdownReaders getter to combine reader arrays by priority

Tests:
- Add unit test for HTML node conversion (e.g., <b>bold</b>) using a custom HTML reader

Chores:
- Export MARKDOWN_READER_LEVEL constants and SerializedMentionNode type in plugin index files