### PR TITLE
🐛 fix: Fix html paste and cmd+shift+v

### DIFF
--- a/src/const/hotkey.ts
+++ b/src/const/hotkey.ts
@@ -69,4 +69,10 @@ export const HOTKEYS_REGISTRATION: HotkeyRegistration = [
     priority: COMMAND_PRIORITY_EDITOR,
     scopes: [HotkeyScopeEnum.Insert, HotkeyScopeEnum.Plugin],
   },
+  {
+    id: HotkeyEnum.PasteAsPlainText,
+    keys: combineKeys([KeyEnum.Mod, KeyEnum.Shift, 'v']),
+    priority: COMMAND_PRIORITY_EDITOR,
+    scopes: [HotkeyScopeEnum.Format],
+  },
 ];

--- a/src/plugins/common/plugin/register.ts
+++ b/src/plugins/common/plugin/register.ts
@@ -196,6 +196,29 @@ export function registerRichKeydown(
 
   return mergeRegister(
     kernel.registerHotkey(
+      HotkeyEnum.PasteAsPlainText,
+      async () => {
+        try {
+          const text = await navigator.clipboard.readText();
+
+          editor.update(() => {
+            const selection = $getSelection();
+            if (!$isRangeSelection(selection)) return;
+
+            // Simply insert the plain text
+            selection.insertText(text);
+          });
+        } catch (error) {
+          console.error('Failed to paste as plain text:', error);
+        }
+      },
+      {
+        enabled: enableHotkey,
+        preventDefault: true,
+        stopPropagation: true,
+      },
+    ),
+    kernel.registerHotkey(
       HotkeyEnum.Bold,
       () => editor.dispatchCommand(FORMAT_TEXT_COMMAND, 'bold'),
       {

--- a/src/plugins/markdown/plugin/index.ts
+++ b/src/plugins/markdown/plugin/index.ts
@@ -161,17 +161,25 @@ export const MarkdownPlugin: IEditorPluginConstructor<MarkdownPluginOptions> = c
           const clipboardData = event.clipboardData;
           if (!clipboardData) return false;
 
-          // Get plain text content
+          // Get clipboard content
           const text = clipboardData.getData('text/plain');
           const html = clipboardData.getData('text/html');
 
+          // If there's no text content, let Lexical handle it
           if (!text) return false;
 
-          // Check if content contains markdown patterns
+          // If there's HTML content, it's a rich text paste
+          // Let Lexical's rich text handler process it
+          if (html && html.trim()) {
+            console.log('paste content analysis: HTML detected, letting Lexical handle it');
+            return false;
+          }
+
+          // Only handle plain text paste - check for markdown patterns
           const hasMarkdownContent = this.detectMarkdownContent(text);
 
           console.log('paste content analysis:', {
-            hasHTML: !!html,
+            hasHTML: false,
             hasMarkdown: hasMarkdownContent,
             markdownPatterns: this.getMarkdownPatterns(text),
             text: text.slice(0, 100) + (text.length > 100 ? '...' : ''),

--- a/src/types/hotkey.ts
+++ b/src/types/hotkey.ts
@@ -67,6 +67,7 @@ export const HotkeyEnum = {
   Link: 'link',
   Mention: 'mention',
   NumberList: 'numberList',
+  PasteAsPlainText: 'pasteAsPlainText',
   Redo: 'redo',
   Slash: 'slash',
   Strikethrough: 'strikethrough',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- 修复无法粘贴 HTML 文本，比如：https://raw.githubusercontent.com/sunrisewestern/sunrisewestern.github.io/refs/heads/main/OneDrive%E4%BB%A4%E7%89%8C%E8%8E%B7%E5%8F%96%E5%8A%A9%E6%89%8B.html

- 修复无法使用 cmd+shift+v 粘贴为纯文本

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
