### PR TITLE
✨ feat: Add fallback nodes in markdown parsing

### DIFF
--- a/src/plugins/markdown/data-source/markdown/parse.test.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.test.ts
@@ -84,4 +84,15 @@ describe('Markdown to Lexical Conversion', () => {
     // @ts-expect-error not error
     expect(lexical.children[0]?.children?.[1]?.format).toBe(1);
   });
+
+  it('should fallback list', () => {
+    const markdown = '* asd\n* 123\n';
+    const lexical = parseMarkdownToLexical(markdown, {});
+
+    expect(lexical.children.length).toEqual(2);
+    // @ts-expect-error not error
+    expect(lexical.children[0].children.length).toEqual(1);
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[0].text).toEqual('asd');
+  });
 });


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable fallback parsing for unknown Markdown node types by returning their child nodes and streamline HTML node processing, with accompanying tests for list fallback functionality

New Features:
- Implement fallback parsing for unsupported Markdown nodes by returning their parsed child nodes

Enhancements:
- Refactor HTML tag handling and simplify default node conversion logic in convertMdastToLexical

Tests:
- Add a test to verify fallback behavior for list items in Markdown parsing