### PR TITLE
✨ feat: xml in markdown reader process #44

### DIFF
--- a/src/plugins/markdown/data-source/markdown/parse.test.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.test.ts
@@ -109,4 +109,27 @@ describe('Markdown to Lexical Conversion', () => {
     // @ts-expect-error not error
     expect(lexical.children[0].children[1].text).toEqual(' text.');
   });
+
+  it('should output origin xml no reader', () => {
+    const markdown =
+      '不存在从 "int" 转换到 "std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>" 的适当构造函数';
+    const lexical = parseMarkdownToLexical(markdown, {});
+    expect(lexical.children.length).toEqual(1);
+
+    // @ts-expect-error not error
+    expect(lexical.children[0].children.length).toEqual(5);
+
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[0].text).toEqual(
+      '不存在从 "int" 转换到 "std::__cxx11::basic_string<char, std::char_traits',
+    );
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[1].text).toEqual('<char>');
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[2].text).toEqual(', std::allocator');
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[3].text).toEqual('<char>');
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[4].text).toEqual('>" 的适当构造函数');
+  });
 });

--- a/src/plugins/markdown/data-source/markdown/parse.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.ts
@@ -186,6 +186,12 @@ function convertMdastToLexical(
           )
           .filter(Boolean)
           .flat() as MarkdownReadNode[];
+        while (htmlStack.length > 0) {
+          const tag = htmlStack.shift();
+          ctx.pop();
+          // @ts-expect-error not error
+          children.push(INodeHelper.createTextNode(tag?.node.value), ...tag.children);
+        }
       }
 
       if (markdownReaders[node.type]) {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

markdown xml 改成单行读取
<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Enable inline XML processing in markdown parsing by draining the HTML stack into text nodes and add a corresponding unit test

New Features:
- Support for single-line XML tag processing in the markdown reader by flushing remaining HTML stack tags into lexical nodes

Tests:
- Add a new test to verify inline XML tags are converted to separate lexical text nodes without a dedicated reader