### PR TITLE
🐛 fix: Update ListPlugin to keep node unchanged instead of throwing a…

### DIFF
--- a/src/plugins/list/plugin/index.test.ts
+++ b/src/plugins/list/plugin/index.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+import { Kernel } from '@/editor-kernel/kernel';
+import { CodeblockPlugin } from '@/plugins/codeblock';
+import { CommonPlugin } from '@/plugins/common';
+import { MarkdownPlugin } from '@/plugins/markdown';
+
+import { ListPlugin } from './';
+
+const codediv = '```';
+
+describe('List Plugin', () => {
+  it('badcase: list contains codeblock', () => {
+    const markdown = `-   Item 1
+    ${codediv}js
+    console.log('Hello, world!');
+    ${codediv}
+-   Item 2`;
+
+    const editor = new Kernel();
+    editor.registerPlugins([MarkdownPlugin, CommonPlugin, CodeblockPlugin, ListPlugin]);
+
+    editor.setRootElement(document.createElement('div'));
+
+    editor.setDocument('markdown', markdown);
+
+    const { root } = editor.getDocument('json') as any;
+    expect(root.children.length).toBe(1);
+    expect(root.children[0].type).toBe('list');
+    expect(root.children[0].children.length).toBe(3);
+    expect(root.children[0].children[1].type).toBe('listitem');
+    expect(root.children[0].children[1].children.length).toBe(1);
+    expect(root.children[0].children[1].children[0].type).toBe('text');
+    expect(root.children[0].children[1].children[0].text).toBe("console.log('Hello, world!');");
+  });
+});

--- a/src/plugins/list/plugin/index.ts
+++ b/src/plugins/list/plugin/index.ts
@@ -193,7 +193,8 @@ export const ListPlugin: IEditorPluginConstructor<ListPluginOptions> = class
             version: 1,
           });
         }
-        throw new Error('ListItem node children must be paragraph or list node ' + v.type);
+        // keep node unchanged
+        return v;
       });
     });
   }


### PR DESCRIPTION
…n error

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

修复 markdown list 包含 codeblock 报错的问题

<!-- Thank you for your Pull Request. Please provide a description above. -->

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Prevent errors when a markdown list contains code blocks by preserving unsupported child nodes in the ListPlugin, and introduce a unit test for this scenario.

Bug Fixes:
- Update ListPlugin to return unsupported nodes unchanged instead of throwing an error when parsing list items

Tests:
- Add a unit test for ListPlugin to verify handling of lists containing code blocks