### PR TITLE
🐛 fix: resolve issues with markdown parsing for XML and inlineCode

### DIFF
--- a/src/plugins/markdown/data-source/markdown/parse.test.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.test.ts
@@ -132,4 +132,27 @@ describe('Markdown to Lexical Conversion', () => {
     // @ts-expect-error not error
     expect(lexical.children[0].children[4].text).toEqual('>" 的适当构造函数');
   });
+
+  it('should output origin xml no reader case 2', () => {
+    const markdown = 'sql<number>`COALESCE(SUM(${plugins.installCount}), 0)`';
+    const lexical = parseMarkdownToLexical(markdown, {
+      inlineCode: (node, children) => {
+        return [INodeHelper.createTextNode('`' + node.value + '`')];
+      },
+    });
+
+    expect(lexical.children.length).toEqual(1);
+
+    // @ts-expect-error not error
+    expect(lexical.children[0].children.length).toEqual(3);
+
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[0].text).toEqual('sql');
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[1].text).toEqual('<number>');
+    // @ts-expect-error not error
+    expect(lexical.children[0].children[2].text).toEqual(
+      '`COALESCE(SUM(${plugins.installCount}), 0)`',
+    );
+  });
 });

--- a/src/plugins/markdown/data-source/markdown/parse.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.ts
@@ -190,7 +190,8 @@ function convertMdastToLexical(
           const tag = htmlStack.shift();
           ctx.pop();
           // @ts-expect-error not error
-          children.push(INodeHelper.createTextNode(tag?.node.value), ...tag.children);
+          children.push(INodeHelper.createTextNode(tag?.node.value), ...tag.children.flat());
+          children = children.flat();
         }
       }
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->

修复 #59 xml + inlineCode markdown解析报错的问题

close #59

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix markdown-to-lexical conversion errors involving XML-like tags and inline code by flattening nested children arrays and updating the inlineCode handler, and add a test to validate the fix

Bug Fixes:
- Fix nested children flattening in convertMdastToLexical to prevent XML/HTML tag parsing errors
- Ensure inlineCode plugin preserves XML-like syntax correctly in inline code nodes

Tests:
- Add test case to verify parsing of inline code with embedded XML-like tags