### PR TITLE
🐛 fix: block image selection

### DIFF
--- a/src/plugins/common/plugin/register.ts
+++ b/src/plugins/common/plugin/register.ts
@@ -399,7 +399,11 @@ export function registerRichKeydown(
   );
 }
 
-const NEEDS_FOLLOWING_PARAGRAPH_TYPES = new Set<string | undefined>(['code', 'table']);
+const NEEDS_FOLLOWING_PARAGRAPH_TYPES = new Set<string | undefined>([
+  'code',
+  'table',
+  'block-image',
+]);
 
 export function registerLastElement(editor: LexicalEditor) {
   let isProcessing = false;

--- a/src/plugins/image/command/index.ts
+++ b/src/plugins/image/command/index.ts
@@ -60,7 +60,7 @@ export function registerImageCommand(
               src: placeholderURL,
             });
         $insertNodes([imageNode]); // Insert a zero-width space to ensure the image is not the last child
-        if ($isRootOrShadowRoot(imageNode.getParentOrThrow())) {
+        if (!block && $isRootOrShadowRoot(imageNode.getParentOrThrow())) {
           $wrapNodeInElement(imageNode, $createParagraphNode).selectEnd();
         }
         handleUpload(file)


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
修复图片选区问题

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix image handling to avoid selection issues when inserting images into the editor.

Bug Fixes:
- Ensure block images are treated as requiring a following paragraph-like element to maintain correct cursor behavior at the end of the document.
- Avoid wrapping images in an extra paragraph when they are inserted as block images at the root, preventing incorrect image selection and focus.