### PR TITLE
✨ feat: Improve editor event handling and link toolbar state management

### DIFF
--- a/src/editor-kernel/react/useEditable.ts
+++ b/src/editor-kernel/react/useEditable.ts
@@ -13,9 +13,14 @@ export const useEditable = () => {
     const updateEditable = (newEditable: boolean) => {
       setEditable(newEditable);
     };
+    const handleInitialized = () => {
+      setEditable(editor.isEditable());
+    };
     editor.on('editableChange', updateEditable);
+    editor.on('initialized', handleInitialized);
     return () => {
       editor.off('editableChange', updateEditable);
+      editor.off('initialized', handleInitialized);
     };
   }, [editor]);
 

--- a/src/plugins/link/react/components/LinkEdit.tsx
+++ b/src/plugins/link/react/components/LinkEdit.tsx
@@ -181,46 +181,49 @@ const LinkEdit = memo<LinkEditProps>(({ editor }) => {
     };
   }, [linkDom]);
 
-  useLexicalEditor((editor) => {
-    return mergeRegister(
-      editor.registerCommand(
-        EDIT_LINK_COMMAND,
-        (payload) => {
-          if (!payload.linkNode || !payload.linkNodeDOM) {
-            handleCancel();
-            return false;
-          }
-          linkNodeRef.current = payload.linkNode;
-          setLinkUrl(payload.linkNode.getURL());
-          setLinkText(payload.linkNode.getTextContent());
-          setLinkDom(payload.linkNodeDOM);
-          return true;
-        },
-        COMMAND_PRIORITY_EDITOR,
-      ),
-      editor.registerCommand(
-        KEY_ESCAPE_COMMAND,
-        () => {
-          handleCancel();
-          return true;
-        },
-        COMMAND_PRIORITY_EDITOR,
-      ),
-      editor.registerCommand(
-        KEY_TAB_COMMAND,
-        (payload) => {
-          if (linkNodeRef.current && linkTextInputRef.current) {
-            payload.stopImmediatePropagation();
-            payload.preventDefault();
-            linkTextInputRef.current.focus();
+  useLexicalEditor(
+    (editor) => {
+      return mergeRegister(
+        editor.registerCommand(
+          EDIT_LINK_COMMAND,
+          (payload) => {
+            if (!payload.linkNode || !payload.linkNodeDOM) {
+              handleCancel();
+              return false;
+            }
+            linkNodeRef.current = payload.linkNode;
+            setLinkUrl(payload.linkNode.getURL());
+            setLinkText(payload.linkNode.getTextContent());
+            setLinkDom(payload.linkNodeDOM);
             return true;
-          }
-          return false;
-        },
-        COMMAND_PRIORITY_NORMAL,
-      ),
-    );
-  }, []);
+          },
+          COMMAND_PRIORITY_EDITOR,
+        ),
+        editor.registerCommand(
+          KEY_ESCAPE_COMMAND,
+          () => {
+            handleCancel();
+            return true;
+          },
+          COMMAND_PRIORITY_EDITOR,
+        ),
+        editor.registerCommand(
+          KEY_TAB_COMMAND,
+          (payload) => {
+            if (linkNodeRef.current && linkTextInputRef.current) {
+              payload.stopImmediatePropagation();
+              payload.preventDefault();
+              linkTextInputRef.current.focus();
+              return true;
+            }
+            return false;
+          },
+          COMMAND_PRIORITY_NORMAL,
+        ),
+      );
+    },
+    [editor],
+  );
 
   if (!linkNodeRef.current || !editable) return null;
 

--- a/src/plugins/link/react/components/LinkToolbar.tsx
+++ b/src/plugins/link/react/components/LinkToolbar.tsx
@@ -108,6 +108,7 @@ const LinkToolbar = memo<LinkToolbarProps>(({ editor, enable }) => {
               const node = getSelectedNode(selection);
               const parent = node.getParent();
               const isLink = $isLinkNode(parent) || $isLinkNode(node);
+              if (isLink === state.current.isLink) return;
               state.current.isLink = isLink;
               if (isLink) {
                 const linkNode = $isLinkNode(parent) ? (parent as LinkNode) : (node as LinkNode);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
1. 修复 link 不展示编辑器的问题

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Improve link editing behavior and editor editable state synchronization.

New Features:
- Initialize the editable state hook based on the editor's initial editable status when the editor is initialized.

Bug Fixes:
- Ensure link edit UI closes when edit payload is missing link data instead of leaving stale state.
- Prevent unnecessary updates of the link toolbar when link selection state has not changed.
- Fix Tab key focus handling in the link edit UI so focus reliably moves to the link text input when appropriate.