### PR TITLE
✨ feat: add support for inserting elements before and after the root …

### DIFF
--- a/src/plugins/litexml/__test__/command.test.ts
+++ b/src/plugins/litexml/__test__/command.test.ts
@@ -243,7 +243,6 @@ describe('Common Plugin Tests', () => {
 
   it('should list item add work', async () => {
     kernel.setDocument('markdown', '- Item 1\n- Item 2\n- Item 3\n\n');
-    console.info(kernel.getDocument('litexml'));
     kernel.dispatchCommand(LITEXML_INSERT_COMMAND, {
       delay: true,
       afterId: 'm1v0', // id of 'Item 2'
@@ -264,5 +263,57 @@ describe('Common Plugin Tests', () => {
     await moment();
     const markdownAfter = kernel.getDocument('markdown') as unknown as string;
     expect(markdownAfter).toBe('- Item 1\n- Item 2\n- New Item\n- Item 3\n');
+  });
+
+  it('should insert after root work', async () => {
+    kernel.setDocument('markdown', 'Paragraph 1\nParagraph 2\n');
+    kernel.dispatchCommand(LITEXML_INSERT_COMMAND, {
+      litexml: '<p id="newpara">Inserted Paragraph</p>',
+      afterId: 'root',
+    });
+    await moment();
+    const markdown = kernel.getDocument('markdown') as unknown as string;
+    expect(markdown).toBe('Paragraph 1\nParagraph 2\n\nInserted Paragraph\n');
+  });
+
+  it('should insert before root work', async () => {
+    kernel.setDocument('markdown', 'Paragraph 1\nParagraph 2\n');
+    kernel.dispatchCommand(LITEXML_INSERT_COMMAND, {
+      litexml:
+        '<root><p id="newpara">Inserted Paragraph</p><p id="newpara">Inserted Paragraph2</p></root>',
+      beforeId: 'root',
+    });
+    await moment();
+    const markdown = kernel.getDocument('markdown') as unknown as string;
+    expect(markdown).toBe(
+      'Inserted Paragraph\n\nInserted Paragraph2\n\nParagraph 1\nParagraph 2\n',
+    );
+  });
+
+  it('should insert after delay root work', async () => {
+    kernel.setDocument('markdown', 'Paragraph 1\nParagraph 2\n');
+    kernel.dispatchCommand(LITEXML_INSERT_COMMAND, {
+      litexml: '<p id="newpara">Inserted Paragraph</p>',
+      afterId: 'root',
+      delay: true,
+    });
+    await moment();
+    const markdown = kernel.getDocument('markdown') as unknown as string;
+    expect(markdown).toBe('Paragraph 1\nParagraph 2\n\nInserted Paragraph\n');
+  });
+
+  it('should insert before delay root work', async () => {
+    kernel.setDocument('markdown', 'Paragraph 1\nParagraph 2\n');
+    kernel.dispatchCommand(LITEXML_INSERT_COMMAND, {
+      litexml:
+        '<root><p id="newpara">Inserted Paragraph</p><p id="newpara">Inserted Paragraph2</p></root>',
+      beforeId: 'root',
+      delay: true,
+    });
+    await moment();
+    const markdown = kernel.getDocument('markdown') as unknown as string;
+    expect(markdown).toBe(
+      'Inserted Paragraph\n\nInserted Paragraph2\n\nParagraph 1\nParagraph 2\n',
+    );
   });
 });

--- a/src/plugins/litexml/command/index.ts
+++ b/src/plugins/litexml/command/index.ts
@@ -4,6 +4,7 @@ import { mergeRegister } from '@lexical/utils';
 import {
   $createParagraphNode,
   $getNodeByKey,
+  $getRoot,
   $insertNodes,
   $isElementNode,
   COMMAND_PRIORITY_EDITOR,
@@ -431,9 +432,17 @@ function handleInsert(
     try {
       let referenceNode: LexicalNode | null = null;
       if (isBefore) {
-        referenceNode = $getNodeByKey(charToId(payload.beforeId));
+        if (payload.beforeId === 'root') {
+          referenceNode = $getRoot().getFirstChild();
+        } else {
+          referenceNode = $getNodeByKey(charToId(payload.beforeId));
+        }
       } else {
-        referenceNode = $getNodeByKey(charToId(payload.afterId));
+        if (payload.afterId === 'root') {
+          referenceNode = $getRoot().getLastChild();
+        } else {
+          referenceNode = $getNodeByKey(charToId(payload.afterId));
+        }
       }
 
       if (!referenceNode) {
@@ -445,7 +454,9 @@ function handleInsert(
       );
       if (!delay) {
         if (isBefore) {
-          referenceNode = referenceNode.insertBefore(newNodes);
+          newNodes.reverse().forEach((node: LexicalNode) => {
+            referenceNode = referenceNode!.insertBefore(node);
+          });
         } else {
           newNodes.forEach((node: LexicalNode) => {
             if (referenceNode) {
@@ -471,7 +482,7 @@ function handleInsert(
             diffNode.append(node);
             return diffNode;
           });
-          diffNodes.forEach((diffNode: DiffNode) => {
+          diffNodes.reverse().forEach((diffNode: DiffNode) => {
             if (referenceNode) {
               referenceNode = referenceNode.insertBefore(diffNode);
             }


### PR DESCRIPTION
…in LITEXML_INSERT_COMMAND

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
1. LITEXML_INSERT_COMMAND， LITEXML_MODIFY_COMMAND， insert afterId和beforeID支持 root, 

fix #108 

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->
