### PR TITLE
✨ feat: add pasteAsPlainText option to force plain text paste

### DIFF
--- a/src/plugins/common/react/ReactPlainText.tsx
+++ b/src/plugins/common/react/ReactPlainText.tsx
@@ -38,6 +38,7 @@ const ReactPlainText = memo<ReactPlainTextProps>(
     enableHotkey = true,
     enablePasteMarkdown = true,
     markdownOption = true,
+    pasteAsPlainText = false,
     onKeyDown,
     onFocus,
     onBlur,
@@ -114,9 +115,18 @@ const ReactPlainText = memo<ReactPlainTextProps>(
       editor.registerPlugin(CommonPlugin, {
         enableHotkey,
         markdownOption,
+        pasteAsPlainText,
         theme: restTheme ? { ...computedThemeStyles, ...restTheme } : computedThemeStyles,
       });
-    }, [editor, enableHotkey, enablePasteMarkdown, markdownOption, restTheme, computedThemeStyles]);
+    }, [
+      editor,
+      enableHotkey,
+      enablePasteMarkdown,
+      markdownOption,
+      pasteAsPlainText,
+      restTheme,
+      computedThemeStyles,
+    ]);
 
     useEffect(() => {
       const container = editorContainerRef.current;

--- a/src/plugins/common/react/type.ts
+++ b/src/plugins/common/react/type.ts
@@ -49,6 +49,11 @@ export interface ReactPlainTextProps {
    * Unlike onChange, this won't trigger on cursor movement or selection changes
    */
   onTextChange?: (editor: IEditor) => void;
+  /**
+   * Force paste as plain text, stripping all rich text formatting
+   * @default false
+   */
+  pasteAsPlainText?: boolean;
   style?: CSSProperties;
   theme?: CommonPluginOptions['theme'] & {
     fontSize?: number;

--- a/src/react/Editor/Editor.tsx
+++ b/src/react/Editor/Editor.tsx
@@ -38,6 +38,7 @@ const Editor = memo<EditorProps>(
     autoFocus,
     enablePasteMarkdown = true,
     markdownOption = true,
+    pasteAsPlainText = false,
     onCompositionStart,
     onCompositionEnd,
     onContextMenu,
@@ -114,6 +115,7 @@ const Editor = memo<EditorProps>(
           onKeyDown={onKeyDown}
           onPressEnter={onPressEnter}
           onTextChange={debouncedOnTextChange}
+          pasteAsPlainText={pasteAsPlainText}
           style={style}
           variant={variant}
         >

--- a/src/react/Editor/demos/pasteAsPlainText.tsx
+++ b/src/react/Editor/demos/pasteAsPlainText.tsx
@@ -1,0 +1,42 @@
+import { IEditor } from '@lobehub/editor';
+import { Editor, useEditor } from '@lobehub/editor/react';
+import { debounce } from 'es-toolkit';
+import { type FC, useState } from 'react';
+
+import Container from './Container';
+
+const Demo: FC = () => {
+  const editor = useEditor();
+  const [json, setJson] = useState('');
+  const [markdown, setMarkdown] = useState('');
+
+  const handleChange = debounce((editor: IEditor) => {
+    const markdownContent = editor.getDocument('markdown') as unknown as string;
+    const jsonContent = editor.getDocument('json') as unknown as Record<string, any>;
+    setMarkdown(markdownContent || '');
+    setJson(JSON.stringify(jsonContent || {}, null, 2));
+  }, 300);
+
+  const handleInit = (editor: IEditor) => {
+    // @ts-expect-error for debugging
+    window.editor = editor;
+    handleChange(editor);
+  };
+
+  return (
+    <Container json={json} markdown={markdown}>
+      <Editor
+        content=""
+        editor={editor}
+        onChange={handleChange}
+        onInit={handleInit}
+        pasteAsPlainText
+        placeholder={'Paste some rich text here to test...'}
+        type="text"
+        variant="chat"
+      />
+    </Container>
+  );
+};
+
+export default Demo;

--- a/src/react/Editor/index.md
+++ b/src/react/Editor/index.md
@@ -32,6 +32,12 @@ Editor is a powerful and extensible rich text editor component designed for mode
 
 <code src="./demos/disableMarkdown.tsx" nopadding iframe></code>
 
+## Paste as Plain Text
+
+Force all pasted content to be inserted as plain text, stripping any rich text formatting (bold, italic, links, etc).
+
+<code src="./demos/pasteAsPlainText.tsx" nopadding iframe></code>
+
 ## APIs
 
 ### Editor
@@ -45,6 +51,7 @@ Editor is a powerful and extensible rich text editor component designed for mode
 | editor              | Editor instance to use                                                   | `IEditor`                                                                               | -        |
 | enablePasteMarkdown | Enable automatic markdown formatting for pasted content                  | `boolean`                                                                               | `true`   |
 | markdownOption      | Enable/disable markdown shortcuts granularly                             | `boolean \| MarkdownFormatOptions`                                                      | `true`   |
+| pasteAsPlainText    | Force paste as plain text, stripping all rich text formatting            | `boolean`                                                                               | `false`  |
 | onInit              | Callback called when editor is initialized                               | `(editor: IEditor) => void`                                                             | -        |
 | mentionOption       | Configuration for mention functionality                                  | `MentionOption`                                                                         | `{}`     |
 | onBlur              | Blur event handler                                                       | `FocusEventHandler<HTMLDivElement>`                                                     | -        |


### PR DESCRIPTION
## Summary
- Add `pasteAsPlainText` prop to Editor component that forces all pasted content to be inserted as plain text
- Strips all rich text formatting (bold, italic, links, etc.) when pasting
- File pastes are still handled normally (not affected by this option)

## Implementation
- Added `pasteAsPlainText` option to `CommonPluginOptions` interface
- Intercepts `PASTE_COMMAND` at high priority in CommonPlugin
- Uses `CONTROLLED_TEXT_INSERTION_COMMAND` to insert plain text
- Added demo at `src/react/Editor/demos/pasteAsPlainText.tsx`
- Updated documentation in `src/react/Editor/index.md`

## Usage
```tsx
<Editor
  pasteAsPlainText
  // ... other props
/>
```

## Test plan
- [x] Paste rich text content (e.g., from web page with bold/italic/links) → should be inserted as plain text
- [x] Paste plain text → should work normally
- [x] File paste → should still work normally (not affected)
- [x] Demo page works correctly

Fixes LOBE-2657