### PR TITLE
🐛 fix: add HISTORY_MERGE_TAG to cursor and code inline registration f…

### DIFF
--- a/src/plugins/code/plugin/registry.ts
+++ b/src/plugins/code/plugin/registry.ts
@@ -1,5 +1,5 @@
 import { mergeRegister } from '@lexical/utils';
-import { $getNodeByKey, LexicalEditor } from 'lexical';
+import { $getNodeByKey, HISTORY_MERGE_TAG, LexicalEditor } from 'lexical';
 
 import { $createCursorNode } from '@/plugins/common';
 import { IEditorKernel } from '@/types';
@@ -38,14 +38,19 @@ export function registerCodeInline(
       });
 
       if (needAddBefore.size > 0) {
-        editor.update(() => {
-          needAddBefore.forEach((node) => {
-            const prev = node.getPreviousSibling();
-            if (!prev) {
-              node.insertBefore($createCursorNode());
-            }
-          });
-        });
+        editor.update(
+          () => {
+            needAddBefore.forEach((node) => {
+              const prev = node.getPreviousSibling();
+              if (!prev) {
+                node.insertBefore($createCursorNode());
+              }
+            });
+          },
+          {
+            tag: HISTORY_MERGE_TAG,
+          },
+        );
       }
     }),
     kernel.registerHotkey(

--- a/src/plugins/common/node/cursor.ts
+++ b/src/plugins/common/node/cursor.ts
@@ -10,6 +10,7 @@ import {
   COMMAND_PRIORITY_HIGH,
   DecoratorNode,
   ElementNode,
+  HISTORY_MERGE_TAG,
   KEY_ARROW_LEFT_COMMAND,
   KEY_ARROW_RIGHT_COMMAND,
   KEY_BACKSPACE_COMMAND,
@@ -79,11 +80,16 @@ export function registerCursorNode(editor: LexicalEditor) {
           }
         }
         if (needAddCursor.length > 0) {
-          editor.update(() => {
-            needAddCursor.forEach((node) => {
-              node.insertAfter($createCursorNode());
-            });
-          });
+          editor.update(
+            () => {
+              needAddCursor.forEach((node) => {
+                node.insertAfter($createCursorNode());
+              });
+            },
+            {
+              tag: HISTORY_MERGE_TAG,
+            },
+          );
         }
         return false;
       });
@@ -120,11 +126,16 @@ export function registerCursorNode(editor: LexicalEditor) {
           }
         }
         if (needRemove.size > 0) {
-          editor.update(() => {
-            needRemove.forEach((node) => {
-              node.remove();
-            });
-          });
+          editor.update(
+            () => {
+              needRemove.forEach((node) => {
+                node.remove();
+              });
+            },
+            {
+              tag: HISTORY_MERGE_TAG,
+            },
+          );
         }
         return false;
       });
@@ -142,15 +153,20 @@ export function registerCursorNode(editor: LexicalEditor) {
         const node = selection.anchor.getNode();
         if (node instanceof CursorNode) {
           if (node.__text !== '\uFEFF') {
-            editor.update(() => {
-              node.setTextContent('\uFEFF');
-              const data = node.__text.replace('\uFEFF', '');
-              if (data) {
-                const textNode = $createTextNode(data);
-                node.insertAfter(textNode);
-                textNode.selectEnd();
-              }
-            });
+            editor.update(
+              () => {
+                node.setTextContent('\uFEFF');
+                const data = node.__text.replace('\uFEFF', '');
+                if (data) {
+                  const textNode = $createTextNode(data);
+                  node.insertAfter(textNode);
+                  textNode.selectEnd();
+                }
+              },
+              {
+                tag: HISTORY_MERGE_TAG,
+              },
+            );
           }
           return false;
         }


### PR DESCRIPTION
…or improved state management

#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
1. 修复整行 code 无法回退的问题 #106 

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Bug Fixes:
- Fix inability to undo changes involving whole-line code blocks by grouping cursor-related updates into a single history entry.