### PR TITLE
🐛 fix: litexml th reader

### DIFF
--- a/src/plugins/table/plugin/index.ts
+++ b/src/plugins/table/plugin/index.ts
@@ -109,10 +109,16 @@ export const TablePlugin: IEditorPluginConstructor<TablePluginOptions> = class
       const colWidths = colWidthsAttr
         ? colWidthsAttr.split(',').map((width) => parseInt(width, 10))
         : [];
+      let maxTdlen = 1;
+      for (const child of children) {
+        if ((child.children?.length || -1) > maxTdlen) {
+          maxTdlen = child.children.length;
+        }
+      }
       return INodeHelper.createElementNode(TableNode.getType(), {
         children,
         // eslint-disable-next-line unicorn/no-new-array
-        colWidths: colWidths.length > 0 ? colWidths : [750],
+        colWidths: colWidths.length > 0 ? colWidths : new Array(maxTdlen).fill(750 / maxTdlen),
         direction: null,
         format: '',
         indent: 0,
@@ -131,7 +137,7 @@ export const TablePlugin: IEditorPluginConstructor<TablePluginOptions> = class
       });
     });
 
-    litexmlService.registerXMLReader('td', (xmlNode, children) => {
+    const tdReader = (xmlNode: Element, children: any[]) => {
       return INodeHelper.createElementNode(TableCellNode.getType(), {
         backgroundColor: xmlNode.getAttribute('backgroundColor') || null,
         children,
@@ -147,7 +153,9 @@ export const TablePlugin: IEditorPluginConstructor<TablePluginOptions> = class
           : 1,
         version: 1,
       });
-    });
+    };
+    litexmlService.registerXMLReader('th', tdReader);
+    litexmlService.registerXMLReader('td', tdReader);
   }
 
   registerMarkdown() {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

<!-- For change type, change [ ] to [x]. -->

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

<!-- Thank you for your Pull Request. Please provide a description above. -->
1. 修复litexml 对 th 没有读取的问题

#### 📝 补充信息 | Additional Information

<!-- Add any other context about the Pull Request here. -->

## Summary by Sourcery

Fix table XML reading to support header cells and more accurate column width initialization.

Bug Fixes:
- Ensure litexml reader handles <th> elements by reusing the existing table cell reader.
- Initialize table column widths based on the maximum number of cells in table rows when no explicit widths are provided.