### PR TITLE
:sparkles: feat(clipboard): add text/markdown format to copy output

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
   "dependencies": {
     "@floating-ui/dom": "^1.7.4",
     "@floating-ui/react": "^0.27.16",
+    "@lexical/clipboard": "^0.42.0",
     "@lexical/code-core": "^0.42.0",
     "@lexical/dragon": "^0.42.0",
     "@lexical/headless": "^0.42.0",

--- a/src/plugins/markdown/plugin/index.ts
+++ b/src/plugins/markdown/plugin/index.ts
@@ -6,6 +6,8 @@ import {
   $isTextNode,
   COLLABORATION_TAG,
   COMMAND_PRIORITY_CRITICAL,
+  COMMAND_PRIORITY_LOW,
+  COPY_COMMAND,
   HISTORIC_TAG,
   KEY_ENTER_COMMAND,
   LexicalEditor,
@@ -107,6 +109,7 @@ export const MarkdownPlugin: IEditorPluginConstructor<MarkdownPluginOptions> = c
 {
   static pluginName = 'MarkdownPlugin';
   private logger = createDebugLogger('plugin', 'markdown');
+  private markdownDataSource: MarkdownDataSource;
   private service: MarkdownShortCutService;
 
   constructor(
@@ -116,11 +119,14 @@ export const MarkdownPlugin: IEditorPluginConstructor<MarkdownPluginOptions> = c
     super();
     this.service = new MarkdownShortCutService(kernel);
     kernel.registerService(IMarkdownShortCutService, this.service);
-    kernel.registerDataSource(
-      new MarkdownDataSource('markdown', this.service, <T>(serviceId: IServiceID<T>) => {
+    this.markdownDataSource = new MarkdownDataSource(
+      'markdown',
+      this.service,
+      <T>(serviceId: IServiceID<T>) => {
         return kernel.requireService(serviceId);
-      }),
+      },
     );
+    kernel.registerDataSource(this.markdownDataSource);
   }
 
   onInit(editor: LexicalEditor): void {
@@ -297,6 +303,35 @@ export const MarkdownPlugin: IEditorPluginConstructor<MarkdownPluginOptions> = c
     );
 
     this.register(registerMarkdownCommand(editor, this.kernel, this.service));
+
+    // Register COPY_COMMAND handler to add text/markdown format to clipboard
+    this.register(
+      editor.registerCommand(
+        COPY_COMMAND,
+        (event) => {
+          if (!(event instanceof ClipboardEvent)) return false;
+
+          const clipboardData = event.clipboardData;
+          if (!clipboardData) return false;
+
+          // Get the selection and convert to markdown
+          const markdown = this.markdownDataSource.write(editor, { selection: true });
+          if (!markdown) return false;
+
+          // Set the markdown format on the clipboard
+          // This will be in addition to the default text/html and text/plain formats
+          // that Lexical already sets
+          clipboardData.setData('text/markdown', markdown);
+
+          this.logger.debug('copy with text/markdown:', { markdownLength: markdown.length });
+
+          // Return false to allow Lexical's default copy behavior to continue
+          // This ensures text/html and text/plain are also set
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
   }
 
   /**

--- a/src/plugins/markdown/plugin/index.ts
+++ b/src/plugins/markdown/plugin/index.ts
@@ -1,3 +1,7 @@
+import {
+  $getClipboardDataFromSelection,
+  setLexicalClipboardDataTransfer,
+} from '@lexical/clipboard';
 import { $isCodeNode } from '@lexical/code-core';
 import {
   $getNodeByKey,
@@ -304,7 +308,9 @@ export const MarkdownPlugin: IEditorPluginConstructor<MarkdownPluginOptions> = c
 
     this.register(registerMarkdownCommand(editor, this.kernel, this.service));
 
-    // Register COPY_COMMAND handler to add text/markdown format to clipboard
+    // Register COPY_COMMAND handler to set text/plain as markdown
+    // This runs before Lexical's default EDITOR handler, handles the copy fully,
+    // and returns true to prevent Lexical from overwriting text/plain with unformatted text
     this.register(
       editor.registerCommand(
         COPY_COMMAND,
@@ -314,20 +320,28 @@ export const MarkdownPlugin: IEditorPluginConstructor<MarkdownPluginOptions> = c
           const clipboardData = event.clipboardData;
           if (!clipboardData) return false;
 
-          // Get the selection and convert to markdown
+          const selection = $getSelection();
+          if (!selection || selection.isCollapsed()) return false;
+
+          // Get the selection as markdown
           const markdown = this.markdownDataSource.write(editor, { selection: true });
           if (!markdown) return false;
 
-          // Set the markdown format on the clipboard
-          // This will be in addition to the default text/html and text/plain formats
-          // that Lexical already sets
+          event.preventDefault();
+
+          // Get HTML and Lexical JSON from Lexical's clipboard utilities
+          const data = $getClipboardDataFromSelection(selection);
+
+          // Set all Lexical clipboard data (text/html, application/x-lexical-editor)
+          setLexicalClipboardDataTransfer(clipboardData, data);
+
+          // Override text/plain with markdown and add text/markdown
+          clipboardData.setData('text/plain', markdown);
           clipboardData.setData('text/markdown', markdown);
 
           this.logger.debug('copy with text/markdown:', { markdownLength: markdown.length });
 
-          // Return false to allow Lexical's default copy behavior to continue
-          // This ensures text/html and text/plain are also set
-          return false;
+          return true;
         },
         COMMAND_PRIORITY_LOW,
       ),

--- a/src/plugins/slash/service/i-slash-service.ts
+++ b/src/plugins/slash/service/i-slash-service.ts
@@ -66,7 +66,7 @@ export const ISlashService: IServiceID<ISlashService> = genServiceId<ISlashServi
 export class SlashService implements ISlashService {
   private triggerMap: Map<string, SlashOptions> = new Map();
   private triggerFnMap: Map<string, ReturnType<typeof getBasicTypeaheadTriggerMatch>> = new Map();
-  private triggerFuseMap: Map<string, Fuse<ISlashOption>> = new Map();
+  private triggerFuseMap: Map<string, Fuse<ISlashMenuOption>> = new Map();
   private logger = createDebugLogger('service', 'slash');
 
   constructor(private kernel: IEditorKernel) {}
@@ -128,7 +128,7 @@ export class SlashService implements ISlashService {
     return this.triggerFnMap.get(trigger);
   }
 
-  getSlashFuse(trigger: string): Fuse<ISlashOption> | undefined {
+  getSlashFuse(trigger: string): Fuse<ISlashMenuOption> | undefined {
     return this.triggerFuseMap.get(trigger);
   }
 }


### PR DESCRIPTION
Add COPY_COMMAND handler to MarkdownPlugin that serializes selected content to markdown and sets it as text/markdown on the clipboard. This enables pasting content as markdown in VSCode and other plain text editors.

Also fix type error in SlashService where the Fuse type was incorrectly defined as ISlashOption instead of ISlashMenuOption (dividers are filtered out before indexing).

https://claude.ai/code/session_01YQYNyYaQjSR5MMfU6ePiAg
