### PR TITLE
✨ feat(headless): add editor API for transforms without React

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,10 @@
       "types": "./es/index.d.ts",
       "import": "./es/index.js"
     },
+    "./headless": {
+      "types": "./es/headless.d.ts",
+      "import": "./es/headless.js"
+    },
     "./react": {
       "types": "./es/react.d.ts",
       "import": "./es/react.js"

--- a/src/editor-kernel/kernel.ts
+++ b/src/editor-kernel/kernel.ts
@@ -172,7 +172,11 @@ export class Kernel extends EventEmitter implements IEditorKernel {
   destroy() {
     unregisterEditorKernel(this.themes[EDITOR_THEME_KEY]);
     this.logger.info(`🗑️ Destroying editor with ${this.pluginsInstances.length} plugins`);
-    this.editor?.setEditorState(createEmptyEditorState());
+    try {
+      this.editor?.setEditorState(createEmptyEditorState());
+    } catch (error) {
+      this.logger.warn('Failed to reset editor state during destroy:', error);
+    }
     this.dataTypeMap.clear();
     this.pluginsInstances.forEach((plugin) => {
       if (plugin.destroy) {

--- a/src/editor-kernel/kernel.ts
+++ b/src/editor-kernel/kernel.ts
@@ -1,3 +1,4 @@
+import { createHeadlessEditor as createLexicalHeadlessEditor } from '@lexical/headless';
 import { HistoryState, createEmptyHistoryState } from '@lexical/history';
 import { $createTableSelection, $isTableNode, $isTableSelection } from '@lexical/table';
 import { get, merge, template, templateSettings } from 'es-toolkit/compat';
@@ -84,6 +85,7 @@ export class Kernel extends EventEmitter implements IEditorKernel {
   private historyState = createEmptyHistoryState();
 
   private editor?: LexicalEditor;
+  private headlessEditor = false;
 
   constructor() {
     super();
@@ -184,16 +186,23 @@ export class Kernel extends EventEmitter implements IEditorKernel {
     this.decorators = {};
     // Clear themes
     this.themes = {};
+    this.headlessEditor = false;
     this.logger.info('✅ Editor destroyed');
   }
 
   getRootElement(): HTMLElement | null {
+    if (this.headlessEditor) {
+      return null;
+    }
     return this.editor?.getRootElement() || null;
   }
 
   setRootElement(dom: HTMLElement, editable: boolean = true): LexicalEditor {
     // Check if editor is already initialized to prevent re-initialization
     if (this.editor) {
+      if (this.headlessEditor) {
+        throw new Error('Headless editor cannot be attached to a root element.');
+      }
       this.logger.warn('[Editor] Editor is already initialized, updating root element only');
       this.editor.setRootElement(dom);
       return this.editor;
@@ -222,6 +231,7 @@ export class Kernel extends EventEmitter implements IEditorKernel {
       },
       theme: this.themes,
     }));
+    this.headlessEditor = false;
     this.editor.setRootElement(dom);
     registerEvent(editor, dom);
 
@@ -268,11 +278,48 @@ export class Kernel extends EventEmitter implements IEditorKernel {
       },
       theme: this.themes,
     }));
+    this.headlessEditor = false;
 
     this.pluginsInstances.forEach((plugin) => {
       plugin.onInit?.(editor);
     });
     this.logger.info(`✅ Editor ready with ${this.pluginsInstances.length} plugins`);
+    this.emit('initialized', editor);
+
+    return editor || null;
+  }
+
+  initHeadlessEditor() {
+    if (this.editor) {
+      return this.editor;
+    }
+    // Initialize plugins if not already done
+    if (this.pluginsInstances.length === 0) {
+      this.logger.info(`🔌 Initializing ${this.plugins.length} plugins`);
+      for (const plugin of this.plugins) {
+        const instance = new plugin(this, this.pluginsConfig.get(plugin));
+        this.pluginsInstances.push(instance);
+      }
+    }
+
+    this.logger.info(`📝 Creating headless editor with ${this.nodes.length} nodes`);
+    const editor = (this.editor = createLexicalHeadlessEditor({
+      // @ts-expect-error Inject into lexical editor instance
+      __kernel: this,
+      namespace: 'lobehub-headless',
+      nodes: this.nodes,
+      onError: (error: Error) => {
+        this.logger.error('❌ Lexical headless editor error:', error);
+        this.emit('error', error);
+      },
+      theme: this.themes,
+    }));
+    this.headlessEditor = true;
+
+    this.pluginsInstances.forEach((plugin) => {
+      plugin.onInit?.(editor);
+    });
+    this.logger.info(`✅ Headless editor ready with ${this.pluginsInstances.length} plugins`);
     this.emit('initialized', editor);
 
     return editor || null;
@@ -430,10 +477,16 @@ export class Kernel extends EventEmitter implements IEditorKernel {
   }
 
   focus() {
+    if (this.headlessEditor) {
+      return;
+    }
     this.editor?.focus();
   }
 
   blur(): void {
+    if (this.headlessEditor) {
+      return;
+    }
     this.editor?.blur();
   }
 

--- a/src/headless/__tests__/headless-editor.test.ts
+++ b/src/headless/__tests__/headless-editor.test.ts
@@ -49,6 +49,20 @@ describe('HeadlessEditor', () => {
     expect(findTextNode(editorData.root, 'Second')).not.toBeNull();
   });
 
+  it('supports Markdown tables in headless mode', () => {
+    const editor = createHeadlessEditor();
+
+    editor.hydrateMarkdown('| Feature | Status |\n| --- | --- |\n| Table | Supported |');
+
+    const { litexml, markdown } = editor.export({ litexml: true });
+
+    expect(litexml).toContain('<table');
+    expect(litexml).toContain('<td');
+    expect(markdown).toContain('Feature');
+    expect(markdown).toContain('Supported');
+    editor.destroy();
+  });
+
   it('hydrates JSON editor data without losing Markdown semantics', () => {
     const source = createHeadlessEditor();
     source.hydrateMarkdown('Plain **bold** text');

--- a/src/headless/__tests__/headless-editor.test.ts
+++ b/src/headless/__tests__/headless-editor.test.ts
@@ -63,6 +63,72 @@ describe('HeadlessEditor', () => {
     editor.destroy();
   });
 
+  it('hydrates editor data with code blocks and horizontal rules', () => {
+    const editor = createHeadlessEditor();
+    const legacyEditorData = {
+      root: {
+        children: [
+          {
+            code: "console.log('hello');",
+            codeTheme: 'default',
+            id: '10',
+            language: 'javascript',
+            options: {
+              indentWithTabs: false,
+              lineNumbers: false,
+              tabSize: 2,
+            },
+            type: 'code',
+            version: 1,
+          },
+          {
+            id: '11',
+            type: 'horizontalrule',
+            version: 1,
+          },
+          {
+            children: [
+              {
+                detail: 0,
+                format: 0,
+                id: '13',
+                mode: 'normal',
+                style: '',
+                text: 'After code',
+                type: 'text',
+                version: 1,
+              },
+            ],
+            direction: 'ltr',
+            format: '',
+            id: '12',
+            indent: 0,
+            tag: 'h2',
+            type: 'heading',
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'root',
+        version: 1,
+      },
+    } as unknown as SerializedEditorState<SerializedLexicalNode>;
+
+    editor.hydrateEditorData(legacyEditorData, { keepId: true });
+
+    const { litexml, markdown } = editor.export({ litexml: true });
+
+    expect(litexml).toContain('<code');
+    expect(litexml).toContain('<hr');
+    expect(litexml).toContain('<h2');
+    expect(markdown).toContain("console.log('hello');");
+    expect(markdown).toContain('After code');
+    expect(markdown).not.toContain("console.log('hello');\n---");
+    editor.destroy();
+  });
+
   it('hydrates JSON editor data without losing Markdown semantics', () => {
     const source = createHeadlessEditor();
     source.hydrateMarkdown('Plain **bold** text');

--- a/src/headless/__tests__/headless-editor.test.ts
+++ b/src/headless/__tests__/headless-editor.test.ts
@@ -104,4 +104,15 @@ describe('HeadlessEditor', () => {
     expect(snapshot.litexml).toContain('italic="true"');
     expect(findTextNode(editorData.root, 'Changed body')).not.toBeNull();
   });
+
+  it('destroys a hydrated headless editor without throwing', () => {
+    const editor = createHeadlessEditor({
+      initialValue: {
+        content: 'Disposable content',
+        type: 'markdown',
+      },
+    });
+
+    expect(() => editor.destroy()).not.toThrow();
+  });
 });

--- a/src/headless/__tests__/headless-editor.test.ts
+++ b/src/headless/__tests__/headless-editor.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment node
+import { createHeadlessEditor } from '@lobehub/editor/headless';
+import type { SerializedEditorState, SerializedLexicalNode } from 'lexical';
+import { resetRandomKey } from 'lexical';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+function findTextNode(
+  node: SerializedLexicalNode,
+  text: string,
+): (SerializedLexicalNode & { text: string }) | null {
+  if ('text' in node && node.text === text) {
+    return node as SerializedLexicalNode & { text: string };
+  }
+
+  if ('children' in node && Array.isArray(node.children)) {
+    for (const child of node.children) {
+      const found = findTextNode(child, text);
+      if (found) {
+        return found;
+      }
+    }
+  }
+
+  return null;
+}
+
+function getXmlTextId(xml: string, text: string): string {
+  const match = xml.match(new RegExp(`<span id="([^"]+)"[^>]*>${text}</span>`));
+  expect(match).not.toBeNull();
+  return match![1];
+}
+
+describe('HeadlessEditor', () => {
+  beforeEach(() => {
+    resetRandomKey();
+  });
+
+  it('hydrates Markdown into editor data and Markdown projection', () => {
+    const editor = createHeadlessEditor();
+
+    editor.hydrateMarkdown('# Alpha\n\n- First\n- Second');
+
+    const { editorData, markdown } = editor.export();
+
+    expect(markdown).toBe('# Alpha\n\n- First\n- Second\n');
+    expect(editorData.root.children[0].type).toBe('heading');
+    expect(editorData.root.children[1].type).toBe('list');
+    expect(findTextNode(editorData.root, 'Alpha')).not.toBeNull();
+    expect(findTextNode(editorData.root, 'Second')).not.toBeNull();
+  });
+
+  it('hydrates JSON editor data without losing Markdown semantics', () => {
+    const source = createHeadlessEditor();
+    source.hydrateMarkdown('Plain **bold** text');
+    const editorData = source.export().editorData;
+
+    const target = createHeadlessEditor();
+    target.hydrateEditorData(editorData);
+
+    const snapshot = target.export();
+
+    expect(snapshot.markdown).toBe('Plain **bold** text\n');
+    expect(findTextNode(snapshot.editorData.root, 'bold')).not.toBeNull();
+  });
+
+  it('applies a LiteXML replace operation without a mounted editor', async () => {
+    const editor = createHeadlessEditor();
+    editor.hydrateMarkdown('# Original\n\nBody text');
+    const before = editor.export({ litexml: true });
+    const titleId = getXmlTextId(before.litexml!, 'Original');
+
+    await editor.applyLiteXML({
+      action: 'replace',
+      litexml: `<span id="${titleId}">Updated</span>`,
+    });
+
+    const { editorData, markdown } = editor.export();
+
+    expect(markdown).toBe('# Updated\n\nBody text\n');
+    expect(findTextNode(editorData.root, 'Updated')).not.toBeNull();
+    expect(findTextNode(editorData.root, 'Original')).toBeNull();
+    expect(editor.kernel.getRootElement()).toBeNull();
+  });
+
+  it('exports synchronized editor data, Markdown, and optional LiteXML after mutation', async () => {
+    const editor = createHeadlessEditor({
+      initialValue: {
+        content: '# Title\n\nBody',
+        type: 'markdown',
+      },
+    });
+    const before = editor.export({ litexml: true });
+    const bodyId = getXmlTextId(before.litexml!, 'Body');
+
+    await editor.applyLiteXML({
+      action: 'replace',
+      litexml: `<span id="${bodyId}" italic="true">Changed body</span>`,
+    });
+
+    const snapshot = editor.export({ litexml: true });
+    const editorData = snapshot.editorData as SerializedEditorState<SerializedLexicalNode>;
+
+    expect(snapshot.markdown).toBe('# Title\n\n*Changed body*\n');
+    expect(snapshot.litexml).toContain('italic="true"');
+    expect(findTextNode(editorData.root, 'Changed body')).not.toBeNull();
+  });
+});

--- a/src/headless/index.ts
+++ b/src/headless/index.ts
@@ -1,0 +1,204 @@
+import type { CommandPayloadType, SerializedEditorState, SerializedLexicalNode } from 'lexical';
+
+import Editor, { moment } from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common/plugin';
+import { ListPlugin } from '@/plugins/list/plugin';
+import {
+  LITEXML_APPLY_COMMAND,
+  LITEXML_INSERT_COMMAND,
+  LITEXML_MODIFY_COMMAND,
+  LITEXML_REMOVE_COMMAND,
+} from '@/plugins/litexml/command';
+import { LitexmlPlugin } from '@/plugins/litexml/plugin';
+import { MarkdownPlugin } from '@/plugins/markdown/plugin';
+import type { IDocumentOptions, IEditor, IPlugin } from '@/types';
+
+export type HeadlessDocumentType = 'json' | 'litexml' | 'markdown' | (string & object);
+
+export interface HeadlessEditorHydrationInput {
+  content: unknown;
+  options?: IDocumentOptions;
+  type: HeadlessDocumentType;
+}
+
+export interface HeadlessEditorExportOptions {
+  litexml?: boolean;
+}
+
+export interface HeadlessEditorExport {
+  editorData: SerializedEditorState<SerializedLexicalNode>;
+  litexml?: string;
+  markdown: string;
+}
+
+export interface HeadlessEditorOptions {
+  additionalPlugins?: ReadonlyArray<IPlugin>;
+  initialValue?: HeadlessEditorHydrationInput;
+  plugins?: ReadonlyArray<IPlugin>;
+}
+
+export interface HeadlessLiteXMLReplaceOperation {
+  action: 'apply' | 'replace';
+  delay?: boolean;
+  litexml: string | string[];
+}
+
+export type HeadlessLiteXMLInsertOperation =
+  | {
+      action: 'insert';
+      afterId: string;
+      delay?: boolean;
+      litexml: string;
+    }
+  | {
+      action: 'insert';
+      beforeId: string;
+      delay?: boolean;
+      litexml: string;
+    };
+
+export interface HeadlessLiteXMLRemoveOperation {
+  action: 'remove';
+  delay?: boolean;
+  id: string;
+}
+
+export interface HeadlessLiteXMLBatchOperation {
+  action: 'batch';
+  operations: CommandPayloadType<typeof LITEXML_MODIFY_COMMAND>;
+}
+
+export type HeadlessLiteXMLOperation =
+  | HeadlessLiteXMLBatchOperation
+  | HeadlessLiteXMLInsertOperation
+  | HeadlessLiteXMLRemoveOperation
+  | HeadlessLiteXMLReplaceOperation;
+
+export const DEFAULT_HEADLESS_EDITOR_PLUGINS: ReadonlyArray<IPlugin> = [
+  [CommonPlugin, { enableHotkey: false }],
+  MarkdownPlugin,
+  ListPlugin,
+  LitexmlPlugin,
+];
+
+export class HeadlessEditor {
+  readonly kernel: IEditor;
+
+  constructor(options: HeadlessEditorOptions = {}) {
+    this.kernel = Editor.createEditor();
+
+    const plugins = [
+      ...(options.plugins ?? DEFAULT_HEADLESS_EDITOR_PLUGINS),
+      ...(options.additionalPlugins ?? []),
+    ];
+
+    this.kernel.registerPlugins(plugins);
+    this.kernel.initHeadlessEditor();
+
+    if (options.initialValue) {
+      this.hydrate(options.initialValue);
+    }
+  }
+
+  hydrate(input: HeadlessEditorHydrationInput): this {
+    this.kernel.setDocument(input.type, input.content, input.options);
+    return this;
+  }
+
+  hydrateEditorData(
+    editorData: SerializedEditorState<SerializedLexicalNode> | string,
+    options?: IDocumentOptions,
+  ): this {
+    this.kernel.setDocument('json', editorData, options);
+    return this;
+  }
+
+  hydrateLiteXML(litexml: string, options?: IDocumentOptions): this {
+    this.kernel.setDocument('litexml', litexml, options);
+    return this;
+  }
+
+  hydrateMarkdown(markdown: string, options?: IDocumentOptions): this {
+    this.kernel.setDocument('markdown', markdown, options);
+    return this;
+  }
+
+  async applyLiteXML(
+    operation: HeadlessLiteXMLOperation | ReadonlyArray<HeadlessLiteXMLOperation>,
+  ): Promise<this> {
+    const operations = Array.isArray(operation) ? operation : [operation];
+
+    for (const item of operations) {
+      this.applyLiteXMLOperation(item);
+    }
+
+    await moment();
+    return this;
+  }
+
+  async applyLiteXMLBatch(
+    operations: CommandPayloadType<typeof LITEXML_MODIFY_COMMAND>,
+  ): Promise<this> {
+    this.kernel.dispatchCommand(LITEXML_MODIFY_COMMAND, operations);
+    await moment();
+    return this;
+  }
+
+  export(options: HeadlessEditorExportOptions = {}): HeadlessEditorExport {
+    const snapshot: HeadlessEditorExport = {
+      editorData: this.kernel.getDocument(
+        'json',
+      ) as unknown as SerializedEditorState<SerializedLexicalNode>,
+      markdown: this.kernel.getDocument('markdown') as unknown as string,
+    };
+
+    if (options.litexml) {
+      snapshot.litexml = this.kernel.getDocument('litexml') as unknown as string;
+    }
+
+    return snapshot;
+  }
+
+  exportState(options?: HeadlessEditorExportOptions): HeadlessEditorExport {
+    return this.export(options);
+  }
+
+  destroy(): void {
+    this.kernel.destroy();
+  }
+
+  private applyLiteXMLOperation(operation: HeadlessLiteXMLOperation): void {
+    switch (operation.action) {
+      case 'apply':
+      case 'replace': {
+        this.kernel.dispatchCommand(LITEXML_APPLY_COMMAND, {
+          delay: operation.delay,
+          litexml: operation.litexml,
+        });
+        return;
+      }
+
+      case 'batch': {
+        this.kernel.dispatchCommand(LITEXML_MODIFY_COMMAND, operation.operations);
+        return;
+      }
+
+      case 'insert': {
+        this.kernel.dispatchCommand(LITEXML_INSERT_COMMAND, operation);
+        return;
+      }
+
+      case 'remove': {
+        this.kernel.dispatchCommand(LITEXML_REMOVE_COMMAND, {
+          delay: operation.delay,
+          id: operation.id,
+        });
+        return;
+      }
+    }
+  }
+}
+
+export function createHeadlessEditor(options?: HeadlessEditorOptions): HeadlessEditor {
+  return new HeadlessEditor(options);
+}

--- a/src/headless/index.ts
+++ b/src/headless/index.ts
@@ -1,7 +1,9 @@
 import type { CommandPayloadType, SerializedEditorState, SerializedLexicalNode } from 'lexical';
 
 import Editor, { moment } from '@/editor-kernel';
+import { CodePlugin } from '@/plugins/code/plugin';
 import { CommonPlugin } from '@/plugins/common/plugin';
+import { HRPlugin } from '@/plugins/hr/plugin';
 import { ListPlugin } from '@/plugins/list/plugin';
 import {
   LITEXML_APPLY_COMMAND,
@@ -13,6 +15,8 @@ import { LitexmlPlugin } from '@/plugins/litexml/plugin';
 import { MarkdownPlugin } from '@/plugins/markdown/plugin';
 import { TablePlugin } from '@/plugins/table/plugin';
 import type { IDocumentOptions, IEditor, IPlugin } from '@/types';
+
+import { HeadlessCodeblockPlugin } from './plugins/codeblock';
 
 export type HeadlessDocumentType = 'json' | 'litexml' | 'markdown' | (string & object);
 
@@ -75,9 +79,123 @@ export type HeadlessLiteXMLOperation =
   | HeadlessLiteXMLRemoveOperation
   | HeadlessLiteXMLReplaceOperation;
 
+type SerializedRecord = Record<string, unknown>;
+
+interface NormalizeLegacyEditorDataContext {
+  nextId: number;
+}
+
+const getNumericId = (id: unknown): number | null => {
+  if (typeof id !== 'number' && typeof id !== 'string') return null;
+
+  const numericId = Number(id);
+  return Number.isInteger(numericId) && numericId >= 0 ? numericId : null;
+};
+
+const findMaxSerializedId = (node: unknown): number => {
+  if (!node || typeof node !== 'object') return -1;
+
+  const record = node as SerializedRecord;
+  const id = getNumericId(record.id);
+  const ownMax = id ?? -1;
+
+  if (!Array.isArray(record.children)) return ownMax;
+
+  return record.children.reduce(
+    (maxId: number, child: unknown) => Math.max(maxId, findMaxSerializedId(child)),
+    ownMax,
+  );
+};
+
+const createSerializedId = (context: NormalizeLegacyEditorDataContext) => String(context.nextId++);
+
+const createCodeChildrenFromLegacyCode = (
+  code: string,
+  context: NormalizeLegacyEditorDataContext,
+) =>
+  code.split('\n').flatMap((text, index, array) => {
+    const textNode = {
+      detail: 0,
+      format: 0,
+      id: createSerializedId(context),
+      mode: 'normal',
+      style: '',
+      text,
+      type: 'code-highlight',
+      version: 1,
+    };
+
+    if (index === array.length - 1) {
+      return textNode;
+    }
+
+    return [
+      textNode,
+      {
+        id: createSerializedId(context),
+        type: 'linebreak',
+        version: 1,
+      },
+    ];
+  });
+
+const normalizeLegacyEditorDataNode = (
+  node: unknown,
+  context: NormalizeLegacyEditorDataContext,
+): unknown => {
+  if (!node || typeof node !== 'object') return node;
+
+  const record = node as SerializedRecord;
+  const children = Array.isArray(record.children)
+    ? record.children.map((child: unknown) => normalizeLegacyEditorDataNode(child, context))
+    : record.children;
+
+  if (record.type === 'code' && typeof record.code === 'string' && !Array.isArray(children)) {
+    return {
+      ...record,
+      children: createCodeChildrenFromLegacyCode(record.code, context),
+      direction: record.direction ?? 'ltr',
+      format: record.format ?? '',
+      indent: record.indent ?? 0,
+      language: record.language ?? 'plaintext',
+      theme: record.theme ?? record.codeTheme,
+    };
+  }
+
+  if (Array.isArray(children)) {
+    return {
+      ...record,
+      children,
+    };
+  }
+
+  return record;
+};
+
+const normalizeLegacyEditorData = (
+  editorData: SerializedEditorState<SerializedLexicalNode> | string,
+): SerializedEditorState<SerializedLexicalNode> | string => {
+  const data =
+    typeof editorData === 'string'
+      ? (JSON.parse(editorData) as SerializedEditorState<SerializedLexicalNode>)
+      : editorData;
+
+  const context = {
+    nextId: findMaxSerializedId(data.root) + 1,
+  };
+
+  return {
+    ...data,
+    root: normalizeLegacyEditorDataNode(data.root, context),
+  } as SerializedEditorState<SerializedLexicalNode>;
+};
+
 export const DEFAULT_HEADLESS_EDITOR_PLUGINS: ReadonlyArray<IPlugin> = [
   [CommonPlugin, { enableHotkey: false }],
   MarkdownPlugin,
+  CodePlugin,
+  HeadlessCodeblockPlugin,
+  HRPlugin,
   ListPlugin,
   TablePlugin,
   LitexmlPlugin,
@@ -111,7 +229,7 @@ export class HeadlessEditor {
     editorData: SerializedEditorState<SerializedLexicalNode> | string,
     options?: IDocumentOptions,
   ): this {
-    this.kernel.setDocument('json', editorData, options);
+    this.kernel.setDocument('json', normalizeLegacyEditorData(editorData), options);
     return this;
   }
 

--- a/src/headless/index.ts
+++ b/src/headless/index.ts
@@ -11,6 +11,7 @@ import {
 } from '@/plugins/litexml/command';
 import { LitexmlPlugin } from '@/plugins/litexml/plugin';
 import { MarkdownPlugin } from '@/plugins/markdown/plugin';
+import { TablePlugin } from '@/plugins/table/plugin';
 import type { IDocumentOptions, IEditor, IPlugin } from '@/types';
 
 export type HeadlessDocumentType = 'json' | 'litexml' | 'markdown' | (string & object);
@@ -78,6 +79,7 @@ export const DEFAULT_HEADLESS_EDITOR_PLUGINS: ReadonlyArray<IPlugin> = [
   [CommonPlugin, { enableHotkey: false }],
   MarkdownPlugin,
   ListPlugin,
+  TablePlugin,
   LitexmlPlugin,
 ];
 

--- a/src/headless/plugins/codeblock.ts
+++ b/src/headless/plugins/codeblock.ts
@@ -1,0 +1,123 @@
+import { $isCodeHighlightNode, $isCodeNode, CodeHighlightNode, CodeNode } from '@lexical/code-core';
+import { TabNode } from 'lexical';
+
+import { INodeHelper } from '@/editor-kernel/inode/helper';
+import { KernelPlugin } from '@/editor-kernel/plugin';
+import { getCodeLanguageByInput } from '@/plugins/codeblock/utils/language';
+import { ILitexmlService } from '@/plugins/litexml';
+import { IMarkdownShortCutService } from '@/plugins/markdown/service/shortcut';
+import type { IEditorKernel, IEditorPlugin, IEditorPluginConstructor } from '@/types';
+
+export type HeadlessCodeblockPluginOptions = Record<string, never>;
+
+const createCodeChildren = (code: string) =>
+  code
+    .split('\n')
+    .flatMap((text, index, array) => {
+      const textNode = INodeHelper.createTextNode(text);
+      textNode.type = 'code-highlight';
+
+      if (index === array.length - 1) {
+        return textNode;
+      }
+
+      return [
+        textNode,
+        {
+          type: 'linebreak',
+          version: 1,
+        },
+      ];
+    })
+    .flat();
+
+export const HeadlessCodeblockPlugin: IEditorPluginConstructor<HeadlessCodeblockPluginOptions> = class
+  extends KernelPlugin
+  implements IEditorPlugin<HeadlessCodeblockPluginOptions>
+{
+  static pluginName = 'HeadlessCodeblockPlugin';
+
+  constructor(protected kernel: IEditorKernel) {
+    super();
+    kernel.registerNodes([CodeNode, CodeHighlightNode]);
+    kernel.registerThemes({
+      code: 'editor-code',
+    });
+  }
+
+  onInit(): void {
+    this.registerMarkdown();
+    this.registerLiteXml();
+  }
+
+  registerLiteXml() {
+    const litexmlService = this.kernel.requireService(ILitexmlService);
+    if (!litexmlService) {
+      return;
+    }
+
+    litexmlService.registerXMLWriter(CodeNode.getType(), (node, ctx) => {
+      const codeNode = node as CodeNode;
+      return ctx.createXmlNode(
+        'code',
+        {
+          lang: codeNode.getLanguage() || 'plaintext',
+        },
+        codeNode.getTextContent(),
+      );
+    });
+
+    litexmlService.registerXMLReader('code', (xmlElement: Element, children: any[]) => {
+      const text = children.map((value) => value.text || '').join('');
+      return INodeHelper.createElementNode(CodeNode.getType(), {
+        children: createCodeChildren(text),
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        language: xmlElement.getAttribute('lang'),
+        version: 1,
+      });
+    });
+  }
+
+  registerMarkdown() {
+    const markdownService = this.kernel.requireService(IMarkdownShortCutService);
+    if (!markdownService) {
+      return;
+    }
+
+    markdownService.registerMarkdownWriter(CodeNode.getType(), (ctx, node) => {
+      if ($isCodeNode(node)) {
+        ctx.wrap('```' + (node.getLanguage() || '') + '\n', '\n```\n');
+      }
+    });
+
+    markdownService.registerMarkdownWriter(TabNode.getType(), (ctx) => {
+      ctx.appendLine('  ');
+    });
+
+    markdownService.registerMarkdownWriter(CodeHighlightNode.getType(), (ctx, node) => {
+      if ($isCodeHighlightNode(node)) {
+        ctx.appendLine(node.getTextContent());
+      }
+    });
+
+    markdownService.registerMarkdownWriter('linebreak', (ctx, node) => {
+      if ($isCodeNode(node.getParent())) {
+        ctx.appendLine('\n');
+      }
+    });
+
+    markdownService.registerMarkdownReader('code', (node) => {
+      const language = node.lang ? getCodeLanguageByInput(node.lang) : 'plaintext';
+      return INodeHelper.createElementNode('code', {
+        children: createCodeChildren(node.value),
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        language,
+        version: 1,
+      });
+    });
+  }
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from './editor-kernel';
 export * from './editor-kernel/react';
+export * from './headless';
 export * from './plugins/auto-complete';
 export * from './plugins/code';
 export * from './plugins/codeblock';

--- a/src/plugins/codeblock/plugin/index.ts
+++ b/src/plugins/codeblock/plugin/index.ts
@@ -76,6 +76,10 @@ function toMarkdownTheme(theme: CodeblockPluginOptions['shikiTheme']) {
   return `${theme.light} ${theme.dark}`;
 }
 
+function isHeadlessEditor(editor: LexicalEditor): boolean {
+  return editor._headless === true;
+}
+
 export const CodeblockPlugin: IEditorPluginConstructor<CodeblockPluginOptions> = class
   extends KernelPlugin
   implements IEditorPlugin<CodeblockPluginOptions>
@@ -99,50 +103,57 @@ export const CodeblockPlugin: IEditorPluginConstructor<CodeblockPluginOptions> =
   }
 
   onInit(editor: LexicalEditor): void {
-    if (this.config?.shikiTheme) {
-      this.register(registerCodeHighlighting(editor, CustomShikiTokenizer));
-    } else {
-      this.register(registerCodeHighlighting(editor));
+    if (!isHeadlessEditor(editor)) {
+      if (this.config?.shikiTheme) {
+        this.register(registerCodeHighlighting(editor, CustomShikiTokenizer));
+      } else {
+        this.register(registerCodeHighlighting(editor));
+      }
     }
+
     this.register(registerCodeCommand(editor));
-    this.register(
-      editor.registerCommand(
-        PASTE_COMMAND,
-        (event) => {
-          if (!(event instanceof ClipboardEvent)) return false;
 
-          const clipboardData = event.clipboardData;
-          if (!clipboardData) return false;
+    if (!isHeadlessEditor(editor)) {
+      this.register(
+        editor.registerCommand(
+          PASTE_COMMAND,
+          (event) => {
+            if (!(event instanceof ClipboardEvent)) return false;
 
-          const isInHighlightNodeSelection = editor.getEditorState().read(() => {
-            const sel = $getSelection();
-            if (!$isRangeSelection(sel)) {
-              return false;
-            }
-            let node: TextNode | ElementNode | null = sel.focus.getNode();
-            while (node) {
-              if ($isCodeHighlightNode(node) || $isCodeNode(node)) {
-                return sel;
+            const clipboardData = event.clipboardData;
+            if (!clipboardData) return false;
+
+            const isInHighlightNodeSelection = editor.getEditorState().read(() => {
+              const sel = $getSelection();
+              if (!$isRangeSelection(sel)) {
+                return false;
               }
-              node = node.getParent();
+              let node: TextNode | ElementNode | null = sel.focus.getNode();
+              while (node) {
+                if ($isCodeHighlightNode(node) || $isCodeNode(node)) {
+                  return sel;
+                }
+                node = node.getParent();
+              }
+              return false;
+            });
+
+            if (isInHighlightNodeSelection) {
+              const rawText =
+                clipboardData.getData('text/plain').trimEnd() ||
+                clipboardData.getData('text/uri-list').trimEnd();
+              editor.update(() => {
+                isInHighlightNodeSelection.insertRawText(rawText);
+              });
+              return true;
             }
             return false;
-          });
+          },
+          COMMAND_PRIORITY_EDITOR,
+        ),
+      );
+    }
 
-          if (isInHighlightNodeSelection) {
-            const rawText =
-              clipboardData.getData('text/plain').trimEnd() ||
-              clipboardData.getData('text/uri-list').trimEnd();
-            editor.update(() => {
-              isInHighlightNodeSelection.insertRawText(rawText);
-            });
-            return true;
-          }
-          return false;
-        },
-        COMMAND_PRIORITY_EDITOR,
-      ),
-    );
     this.registerMarkdown();
     this.registerLiteXml();
   }

--- a/src/plugins/list/plugin/checkList.ts
+++ b/src/plugins/list/plugin/checkList.ts
@@ -30,6 +30,10 @@ export const INSERT_CHECK_LIST_COMMAND: LexicalCommand<void> = createCommand(
   'INSERT_CHECK_LIST_COMMAND',
 );
 
+function isHeadlessEditor(editor: LexicalEditor): boolean {
+  return editor._headless === true;
+}
+
 function handleCheckItemEvent(event: PointerEvent, callback: () => void) {
   const target = event.target;
 
@@ -175,7 +179,7 @@ function handleArrowUpOrDown(event: KeyboardEvent, editor: LexicalEditor, backwa
 }
 
 export function registerCheckList(editor: LexicalEditor) {
-  return mergeRegister(
+  const registrations = [
     editor.registerCommand(
       INSERT_CHECK_LIST_COMMAND,
       () => {
@@ -238,16 +242,23 @@ export function registerCheckList(editor: LexicalEditor) {
       },
       COMMAND_PRIORITY_LOW,
     ),
-    editor.registerRootListener((rootElement, prevElement) => {
-      if (rootElement !== null) {
-        rootElement.addEventListener('click', handleClick);
-        rootElement.addEventListener('pointerdown', handlePointerDown);
-      }
+  ];
 
-      if (prevElement !== null) {
-        prevElement.removeEventListener('click', handleClick);
-        prevElement.removeEventListener('pointerdown', handlePointerDown);
-      }
-    }),
-  );
+  if (!isHeadlessEditor(editor)) {
+    registrations.push(
+      editor.registerRootListener((rootElement, prevElement) => {
+        if (rootElement !== null) {
+          rootElement.addEventListener('click', handleClick);
+          rootElement.addEventListener('pointerdown', handlePointerDown);
+        }
+
+        if (prevElement !== null) {
+          prevElement.removeEventListener('click', handleClick);
+          prevElement.removeEventListener('pointerdown', handlePointerDown);
+        }
+      }),
+    );
+  }
+
+  return mergeRegister(...registrations);
 }

--- a/src/plugins/list/plugin/index.ts
+++ b/src/plugins/list/plugin/index.ts
@@ -7,7 +7,6 @@ import {
   registerListStrictIndentTransform,
 } from '@lexical/list';
 import { $getNearestNodeOfType } from '@lexical/utils';
-import { cx } from 'antd-style';
 import { $isRootNode, LexicalEditor } from 'lexical';
 
 import { INodeHelper } from '@/editor-kernel/inode/helper';
@@ -15,6 +14,7 @@ import { KernelPlugin } from '@/editor-kernel/plugin';
 import { ILitexmlService } from '@/plugins/litexml';
 import { IMarkdownShortCutService } from '@/plugins/markdown/service/shortcut';
 import { IEditorKernel, IEditorPlugin, IEditorPluginConstructor } from '@/types';
+import { cx } from '@/utils/cx';
 
 import { listReplace } from '../utils';
 import { registerCheckList } from './checkList';

--- a/src/plugins/markdown/data-source/markdown/parse.ts
+++ b/src/plugins/markdown/data-source/markdown/parse.ts
@@ -1,4 +1,3 @@
-import { preprocessMarkdownContent } from '@lobehub/ui';
 import type { Heading, Html, Paragraph, PhrasingContent, Root, RootContent, Text } from 'mdast';
 import { remark } from 'remark';
 import remarkCjkFriendly from 'remark-cjk-friendly';
@@ -258,7 +257,7 @@ export function parseMarkdownToLexical(
     .use(remarkCjkFriendly)
     .use(remarkMath)
     .use([[remarkGfm, { singleTilde: false }]])
-    .parse(preprocessMarkdownContent(markdown));
+    .parse(markdown);
   logger.debug('Parsed MDAST:', ast);
 
   const ctx = new MarkdownContext(ast);

--- a/src/plugins/table/plugin/index.ts
+++ b/src/plugins/table/plugin/index.ts
@@ -7,7 +7,6 @@ import {
   registerTableSelectionObserver,
   setScrollableTablesActive,
 } from '@lexical/table';
-import { cx } from 'antd-style';
 import { LexicalEditor } from 'lexical';
 
 import { INodeHelper } from '@/editor-kernel/inode/helper';
@@ -15,6 +14,7 @@ import { KernelPlugin } from '@/editor-kernel/plugin';
 import { ILitexmlService } from '@/plugins/litexml';
 import { IMarkdownShortCutService } from '@/plugins/markdown/service/shortcut';
 import type { IEditorKernel, IEditorPlugin, IEditorPluginConstructor } from '@/types';
+import { cx } from '@/utils/cx';
 
 import { registerTableCommand } from '../command';
 import { TableNode, patchTableNode } from '../node';
@@ -27,6 +27,10 @@ export interface TablePluginOptions {
 const tableCellProcessor = (before: string, content: string, after: string) => {
   return before + content.replace(/\n+$/, '').replaceAll(/\n+/g, '<br />') + after;
 };
+
+function isHeadlessEditor(editor: LexicalEditor): boolean {
+  return editor._headless === true;
+}
 
 export const TablePlugin: IEditorPluginConstructor<TablePluginOptions> = class
   extends KernelPlugin
@@ -52,11 +56,14 @@ export const TablePlugin: IEditorPluginConstructor<TablePluginOptions> = class
   }
 
   onInit(editor: LexicalEditor): void {
-    setScrollableTablesActive(editor, true);
-    this.register(registerTablePlugin(editor));
-    this.register(registerTableSelectionObserver(editor));
     this.register(registerTableCellUnmergeTransform(editor));
-    this.register(registerTableCommand(editor));
+
+    if (!isHeadlessEditor(editor)) {
+      setScrollableTablesActive(editor, true);
+      this.register(registerTablePlugin(editor));
+      this.register(registerTableSelectionObserver(editor));
+      this.register(registerTableCommand(editor));
+    }
 
     this.registerMarkdown();
     this.registerLiteXml();

--- a/src/types/kernel.ts
+++ b/src/types/kernel.ts
@@ -149,6 +149,10 @@ export interface IEditor {
    */
   getTheme(): Record<string, string | Record<string, string>>;
   /**
+   * Get headless editor instance
+   */
+  initHeadlessEditor(): LexicalEditor | null;
+  /**
    * Get node editor instance
    */
   initNodeEditor(): LexicalEditor | null;

--- a/src/utils/cx.ts
+++ b/src/utils/cx.ts
@@ -1,0 +1,3 @@
+type ClassNameValue = false | null | string | undefined;
+
+export const cx = (...classNames: ClassNameValue[]) => classNames.filter(Boolean).join(' ');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,6 +19,8 @@
       "@@/*": [".dumi/tmp/*"],
       "@lobehub/editor": ["./src"],
       "@lobehub/editor/*": ["./src/*"],
+      "@lobehub/editor/headless": ["./src/headless"],
+      "@lobehub/editor/headless/*": ["./src/headless/*"],
       "@lobehub/editor/react": ["./src/react"],
       "@lobehub/editor/react/*": ["./src/react/*"],
       "@lobehub/editor/renderer": ["./src/renderer"],

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,18 +1,32 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig({
-  clean: true,
+const commonConfig = {
   deps: {
     onlyBundle: false,
   },
   dts: true,
-  entry: {
-    headless: 'src/headless/index.ts',
-    index: 'src/index.ts',
-    react: 'src/react/index.ts',
-    renderer: 'src/renderer/index.ts',
-  },
   format: 'esm',
   outDir: 'es',
-  platform: 'browser',
-});
+} as const;
+
+export default defineConfig([
+  {
+    ...commonConfig,
+    clean: true,
+    entry: {
+      headless: 'src/headless/index.ts',
+    },
+    outExtensions: () => ({ dts: '.d.ts', js: '.js' }),
+    platform: 'node',
+  },
+  {
+    ...commonConfig,
+    clean: false,
+    entry: {
+      index: 'src/index.ts',
+      react: 'src/react/index.ts',
+      renderer: 'src/renderer/index.ts',
+    },
+    platform: 'browser',
+  },
+]);

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
   },
   dts: true,
   entry: {
+    headless: 'src/headless/index.ts',
     index: 'src/index.ts',
     react: 'src/react/index.ts',
     renderer: 'src/renderer/index.ts',


### PR DESCRIPTION
Introduce headless module with hydration/export, LiteXML batch ops, and tests. Extend kernel for headless lifecycle; tighten checklist behavior; update build and public exports.

Made-with: Cursor
