### PR TITLE
🐛 fix: prevent remark-stringify from unnecessarily escaping underscores

### DIFF
--- a/src/plugins/markdown/data-source/markdown-data-source.ts
+++ b/src/plugins/markdown/data-source/markdown-data-source.ts
@@ -43,7 +43,10 @@ export default class MarkdownDataSource extends DataSource {
           tightDefinitions: true,
         })
         .processSync(markdown);
-      return String(result);
+      // Since emphasis uses '*' and strong uses '*', underscore '_' is never used
+      // as a markdown syntax marker. Revert remark-stringify's unnecessary escaping
+      // of underscores in text nodes.
+      return String(result).replaceAll('\\_', '_');
     } catch (error) {
       logger.error('Failed to format markdown:', error);
       return markdown;


### PR DESCRIPTION
## Summary
- Post-process `formatMarkdown()` output to revert `\_` back to `_`
- Since emphasis uses `*` and strong uses `*`, underscore `_` is never a markdown syntax marker in the output
- remark-stringify escapes `_` to `\_` in text nodes unnecessarily, which breaks literal underscores in user input

## Test plan
- [ ] Type `A_i = k` in the editor and export markdown — should remain `A_i = k` (not `A\_i = k`)
- [ ] Bold/italic formatting with `*` should still work correctly
- [ ] Underscores in code blocks and inline code should be preserved

Fixes lobehub/lobehub#12303