### PR TITLE
🐛 fix: add mermaid to code block language list

### DIFF
--- a/src/plugins/codemirror-block/lib/mode.ts
+++ b/src/plugins/codemirror-block/lib/mode.ts
@@ -62,6 +62,12 @@ export const MODES = [
     syntax: 'markdown',
     value: 'markdown',
   },
+  {
+    ext: ['mmd'],
+    name: 'Mermaid',
+    syntax: 'simplemode',
+    value: 'mermaid',
+  },
   { name: 'MATLAB', syntax: 'octave', value: 'matlab' },
   { ext: ['conf'], name: 'Nginx', syntax: 'nginx', value: 'nginx' },
   {


### PR DESCRIPTION
## Summary
- `codemirror-block` 插件的 `MODES` 数组缺少 `mermaid` 条目
- 编辑含 mermaid 代码块的消息时，`modeMatch('mermaid')` 无匹配，返回 `'plain'`
- 保存后代码块变为 plaintext，无法渲染 mermaid 图

## Fix
在 `MODES` 数组中添加 mermaid 条目（`.mmd` 扩展名，`simplemode` syntax）

## Test plan
- [x] 编辑含 mermaid 代码块的消息后，语言保持为 `mermaid` 而非 `plain`
- [x] 已排序插入（Mermaid 在 Markdown 与 MATLAB 之间）

Closes lobehub/lobehub#12307