### PR TITLE
🐛 fix: handle non-numeric legacy editor ids

### DIFF
--- a/src/headless/__tests__/headless-editor.test.ts
+++ b/src/headless/__tests__/headless-editor.test.ts
@@ -129,6 +129,52 @@ describe('HeadlessEditor', () => {
     editor.destroy();
   });
 
+  it('hydrates editor data with non-numeric legacy ids in keepId mode', () => {
+    const editor = createHeadlessEditor();
+    const legacyEditorData = {
+      root: {
+        children: [
+          {
+            children: [
+              {
+                detail: 0,
+                format: 0,
+                id: 'title-text',
+                mode: 'normal',
+                style: '',
+                text: 'Legacy title',
+                type: 'text',
+                version: 1,
+              },
+            ],
+            direction: 'ltr',
+            format: '',
+            id: 'title-node',
+            indent: 0,
+            tag: 'h1',
+            type: 'heading',
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+        format: '',
+        id: 'root',
+        indent: 0,
+        type: 'root',
+        version: 1,
+      },
+    } as unknown as SerializedEditorState<SerializedLexicalNode>;
+
+    expect(() => editor.hydrateEditorData(legacyEditorData, { keepId: true })).not.toThrow();
+
+    const { litexml, markdown } = editor.export({ litexml: true });
+
+    expect(markdown).toBe('# Legacy title\n');
+    expect(litexml).toContain('<h1');
+    expect(litexml).toContain('Legacy title');
+    editor.destroy();
+  });
+
   it('hydrates JSON editor data without losing Markdown semantics', () => {
     const source = createHeadlessEditor();
     source.hydrateMarkdown('Plain **bold** text');

--- a/src/plugins/common/data-source/json-data-source.ts
+++ b/src/plugins/common/data-source/json-data-source.ts
@@ -77,7 +77,10 @@ export default class JSONDataSource extends DataSource {
             let maxId = -1;
             Array.from(state._nodeMap.keys()).forEach((key) => {
               if (key === 'root') return;
-              maxId = Math.max(maxId, Number(key));
+              const numericKey = Number(key);
+              if (Number.isInteger(numericKey) && numericKey >= 0) {
+                maxId = Math.max(maxId, numericKey);
+              }
             });
             // make sure to reset random key to avoid id conflicts
             resetRandomKey(maxId + 1);

--- a/src/plugins/litexml/utils/index.ts
+++ b/src/plugins/litexml/utils/index.ts
@@ -8,6 +8,13 @@ import {
   resetRandomKey,
 } from 'lexical';
 
+const getNumericId = (id: unknown): number | null => {
+  if (typeof id !== 'number' && typeof id !== 'string') return null;
+
+  const numericId = Number(id);
+  return Number.isInteger(numericId) && numericId >= 0 ? numericId : null;
+};
+
 export function $parseSerializedNodeImpl(
   serializedNode: any,
   editor: LexicalEditor,
@@ -27,8 +34,12 @@ export function $parseSerializedNodeImpl(
     throw new Error(`LexicalNode: Node ${nodeClass.name} does not implement .importJSON().`);
   }
 
-  if (keepId && serializedNode.id) {
-    resetRandomKey(Number(serializedNode.id));
+  if (keepId) {
+    const id = getNumericId(serializedNode.id);
+
+    if (id !== null) {
+      resetRandomKey(id);
+    }
   }
   const node = nodeClass.importJSON(serializedNode);
   const children = serializedNode.children;


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

This PR fixes headless JSON hydration when legacy serialized editor data contains non-numeric node ids.

- Guard `resetRandomKey` so it only receives valid non-negative integer ids during keep-id deserialization.
- Ignore non-numeric node-map keys when computing the next generated Lexical key.
- Add a headless regression test covering legacy string ids on heading/text nodes.

#### 📝 Additional Information

Verification:

- `pnpm vitest run --silent='passed-only' src/headless/__tests__/headless-editor.test.ts src/editor-kernel/__tests__/lexical-patch.test.ts`
- `pnpm type-check`
- `pnpm exec eslint --max-warnings=0 src/plugins/litexml/utils/index.ts src/plugins/common/data-source/json-data-source.ts`
- `pnpm build`
- built `es/headless.js` smoke test for non-numeric legacy ids
