### PR TITLE
💄 style: use filled variant for SendButton generating state

### DIFF
--- a/src/react/SendButton/SendButton.tsx
+++ b/src/react/SendButton/SendButton.tsx
@@ -49,6 +49,7 @@ const SendButton: FC<SendButtonProps> = ({
           ...style,
           width: menu ? size * 2 : size,
         }}
+        variant={'filled'}
         {...rest}
       >
         <StopIcon size={size * 0.75} />


### PR DESCRIPTION
## Summary

In light mode, the SendButton's `generating` state renders the outline-variant Button (`@lobehub/ui` defaults to `outlined` in light mode) **on top of** `StopIcon`'s own circular spinner track. The result is two concentric rings — a "double line" that looks noisy and inconsistent with the rest of the chat input.

This PR defaults the generating-state Button to `variant=\"filled\"`, so the outer border disappears and only the StopIcon's spinner ring remains. Dark mode is unaffected — the Button already defaults to `filled` there, so this change just brings light mode in line.

### Before / After (light mode)

- **Before:** outlined Button border + inner spinner ring → two visible circles around the stop square.
- **After:** soft filled Button (no border) + single spinner ring → cleaner single-ring loading control.

`variant` is placed before `{...rest}`, so callers can still override it if they need the previous look.

## Test plan

- [ ] Open `SendButton` demo (`src/react/SendButton/demos/index.tsx`) in `pnpm dev` and verify `<SendButton generating />` (and the `shape='round'` / `menu` variants) render as a single-ring filled button in light mode.
- [ ] Toggle to dark mode and confirm no visual regression vs. master.
- [ ] Confirm the click handler still triggers `onStop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)