### PR TITLE
:bug: fix(headless): preserve code block line breaks

### DIFF
--- a/src/headless/__tests__/headless-editor.test.ts
+++ b/src/headless/__tests__/headless-editor.test.ts
@@ -130,6 +130,30 @@ describe('HeadlessEditor', () => {
     editor.destroy();
   });
 
+  it('preserves fenced code line breaks in headless editor data', () => {
+    const editor = createHeadlessEditor();
+
+    editor.hydrateMarkdown('```\nconst a = 1\nconst b=  1\n```');
+
+    const { editorData, markdown } = editor.export();
+    const codeNode = findNodeByType(editorData.root, 'code');
+    const codeChildren = Array.isArray(codeNode?.children) ? codeNode.children : [];
+
+    expect(markdown).toBe('```plaintext\nconst a = 1\nconst b=  1\n```\n');
+    expect(codeNode).toMatchObject({
+      code: 'const a = 1\nconst b=  1',
+      type: 'code',
+    });
+    expect(codeChildren).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'const a = 1', type: 'code-highlight' }),
+        expect.objectContaining({ type: 'linebreak' }),
+        expect.objectContaining({ text: 'const b=  1', type: 'code-highlight' }),
+      ]),
+    );
+    editor.destroy();
+  });
+
   it('supports Markdown tables in headless mode', () => {
     const editor = createHeadlessEditor();
 

--- a/src/headless/index.ts
+++ b/src/headless/index.ts
@@ -191,6 +191,56 @@ const normalizeLegacyEditorData = (
   } as SerializedEditorState<SerializedLexicalNode>;
 };
 
+const extractSerializedCodeText = (children: unknown[]): string =>
+  children
+    .map((child) => {
+      if (!child || typeof child !== 'object') return '';
+
+      const record = child as SerializedRecord;
+
+      if (record.type === 'linebreak') return '\n';
+      if (record.type === 'tab') return '\t';
+      if (typeof record.text === 'string') return record.text;
+      if (Array.isArray(record.children)) return extractSerializedCodeText(record.children);
+
+      return '';
+    })
+    .join('');
+
+const preserveSerializedCodeText = (node: unknown): unknown => {
+  if (!node || typeof node !== 'object') return node;
+
+  const record = node as SerializedRecord;
+  const children = Array.isArray(record.children)
+    ? record.children.map((child: unknown) => preserveSerializedCodeText(child))
+    : record.children;
+
+  if (record.type === 'code' && Array.isArray(children)) {
+    return {
+      ...record,
+      children,
+      code: extractSerializedCodeText(children),
+    };
+  }
+
+  if (Array.isArray(children)) {
+    return {
+      ...record,
+      children,
+    };
+  }
+
+  return record;
+};
+
+const preserveSerializedCodeTextInEditorData = (
+  editorData: SerializedEditorState<SerializedLexicalNode>,
+): SerializedEditorState<SerializedLexicalNode> =>
+  ({
+    ...editorData,
+    root: preserveSerializedCodeText(editorData.root),
+  }) as SerializedEditorState<SerializedLexicalNode>;
+
 export const DEFAULT_HEADLESS_EDITOR_PLUGINS: ReadonlyArray<IPlugin> = [
   [CommonPlugin, { enableHotkey: false }],
   MarkdownPlugin,
@@ -268,9 +318,9 @@ export class HeadlessEditor {
 
   export(options: HeadlessEditorExportOptions = {}): HeadlessEditorExport {
     const snapshot: HeadlessEditorExport = {
-      editorData: this.kernel.getDocument(
-        'json',
-      ) as unknown as SerializedEditorState<SerializedLexicalNode>,
+      editorData: preserveSerializedCodeTextInEditorData(
+        this.kernel.getDocument('json') as unknown as SerializedEditorState<SerializedLexicalNode>,
+      ),
       markdown: this.kernel.getDocument('markdown') as unknown as string,
     };
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

Preserve full fenced code block text, including newline characters, on serialized headless editor `code` nodes during export.

This keeps the existing structured `code-highlight` and `linebreak` children while also exposing a complete `code` string for consumers that read editorData directly.

#### 📝 Additional Information

Verification:

- `npm run test -- run src/headless/__tests__/headless-editor.test.ts`
- `npm run type-check`
- pre-commit hook: `type-check`, `lint:circular`, `lint-staged`

No related GitHub issue was found for this exact scope.
