### PR TITLE
🐛 fix(image): persist previewed resize width

### DIFF
--- a/src/plugins/image/demos/data.json
+++ b/src/plugins/image/demos/data.json
@@ -33,6 +33,15 @@
         "version": 1,
         "textFormat": 0,
         "textStyle": ""
+      },
+      {
+        "altText": "Block image resize persistence case",
+        "height": 240,
+        "maxWidth": 320,
+        "src": "https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=640",
+        "type": "block-image",
+        "version": 1,
+        "width": 320
       }
     ],
     "direction": null,

--- a/src/plugins/image/demos/index.tsx
+++ b/src/plugins/image/demos/index.tsx
@@ -1,14 +1,82 @@
-import { ReactEditor, ReactEditorContent, ReactImagePlugin, ReactPlainText } from '@lobehub/editor';
+import {
+  type IEditor,
+  ReactEditor,
+  ReactEditorContent,
+  ReactImagePlugin,
+  ReactPlainText,
+} from '@lobehub/editor';
+import { useMemo, useState } from 'react';
 
 import content from './data.json';
 
+type DemoContent = typeof content;
+
+interface SerializedBlockImage {
+  maxWidth?: number;
+  type: 'block-image';
+  width?: number;
+}
+
+function findBlockImage(node: unknown): SerializedBlockImage | null {
+  if (!node || typeof node !== 'object') return null;
+
+  const value = node as { children?: unknown; maxWidth?: unknown; type?: unknown; width?: unknown };
+  if (value.type === 'block-image') {
+    return {
+      maxWidth: typeof value.maxWidth === 'number' ? value.maxWidth : undefined,
+      type: 'block-image',
+      width: typeof value.width === 'number' ? value.width : undefined,
+    };
+  }
+
+  if (!Array.isArray(value.children)) return null;
+
+  for (const child of value.children) {
+    const image = findBlockImage(child);
+    if (image) return image;
+  }
+
+  return null;
+}
+
 export default () => {
+  const [editorContent, setEditorContent] = useState<DemoContent>(content);
+  const [snapshot, setSnapshot] = useState<DemoContent>(content);
+  const [revision, setRevision] = useState(0);
+
+  const blockImage = useMemo(() => findBlockImage(snapshot.root), [snapshot]);
+
+  const handleChange = (editor: IEditor) => {
+    const nextSnapshot = editor.getDocument('json');
+    if (nextSnapshot) setSnapshot(nextSnapshot as unknown as DemoContent);
+  };
+
+  const handleHydrateSnapshot = () => {
+    setEditorContent(snapshot);
+    setRevision((value) => value + 1);
+  };
+
   return (
-    <ReactEditor>
-      <ReactPlainText>
-        <ReactEditorContent content={content} type="json" />
+    <ReactEditor key={revision}>
+      <ReactPlainText onChange={handleChange}>
+        <ReactEditorContent content={editorContent} type="json" />
       </ReactPlainText>
       <ReactImagePlugin />
+      <div style={{ marginTop: 16 }}>
+        <button onClick={handleHydrateSnapshot} type="button">
+          Hydrate from current JSON
+        </button>
+        <pre style={{ marginTop: 8 }}>
+          {JSON.stringify(
+            {
+              blockImageMaxWidth: blockImage?.maxWidth,
+              blockImageWidth: blockImage?.width,
+            },
+            null,
+            2,
+          )}
+        </pre>
+      </div>
     </ReactEditor>
   );
 };

--- a/src/plugins/image/react/components/Image.tsx
+++ b/src/plugins/image/react/components/Image.tsx
@@ -24,6 +24,12 @@ export interface ImageProps {
   showScaleInfo?: boolean;
 }
 
+function getResizedImageWidth(startWidth: number, deltaX: number, maxWidth: number) {
+  const adjustedDeltaX = deltaX * 2;
+
+  return Math.max(50, Math.min(startWidth + adjustedDeltaX, maxWidth));
+}
+
 const Image = memo<ImageProps>(
   ({ node, className, showScaleInfo = false, handleUpload, onPickFile }) => {
     const [isSelected, setSelected] = useLexicalNodeSelection(node.getKey());
@@ -67,11 +73,8 @@ const Image = memo<ImageProps>(
       const parentWidth = imageRef.current.parentElement?.clientWidth || window.innerWidth;
       const maxWidth = parentWidth;
 
-      // Since image is centered, delta is halved (both sides resize)
-      const adjustedDeltaX = deltaX * 2;
-
       // Use the width captured at mousedown time
-      const newWidth = Math.max(50, Math.min(startWidthRef.current + adjustedDeltaX, maxWidth));
+      const newWidth = getResizedImageWidth(startWidthRef.current, deltaX, maxWidth);
 
       // Calculate new height based on the original aspect ratio
       const newHeight = newWidth / aspectRatio;
@@ -179,11 +182,8 @@ const Image = memo<ImageProps>(
         const parentWidth = imageRef.current.parentElement?.clientWidth || window.innerWidth;
         const maxWidth = parentWidth;
 
-        // Since image is centered, delta is halved (both sides resize)
-        const adjustedDeltaX = deltaX / 2;
-
         // Use the width captured at mousedown time
-        const finalWidth = Math.max(50, Math.min(startWidthRef.current + adjustedDeltaX, maxWidth));
+        const finalWidth = getResizedImageWidth(startWidthRef.current, deltaX, maxWidth);
 
         // persist to node via editor.update
         const editor = editorRef.current;

--- a/src/plugins/image/react/components/__tests__/Image.test.tsx
+++ b/src/plugins/image/react/components/__tests__/Image.test.tsx
@@ -1,0 +1,138 @@
+import { act } from 'react';
+import type { ReactNode } from 'react';
+import { type Root, createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Image from '../Image';
+import type { ResizeHandleProps } from '../ResizeHandle';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const mocks = vi.hoisted(() => {
+  const editor = {
+    registerCommand: vi.fn(() => vi.fn()),
+    update: vi.fn((callback: () => void) => callback()),
+  };
+
+  return {
+    editor,
+    resizeHandleProps: [] as ResizeHandleProps[],
+  };
+});
+
+vi.mock('@/editor-kernel/react/useLexicalEditor', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    useLexicalEditor: (handleEditor: (editor: typeof mocks.editor) => void) => {
+      React.useEffect(() => {
+        handleEditor(mocks.editor);
+      }, [handleEditor]);
+    },
+  };
+});
+
+vi.mock('@/editor-kernel/react/useLexicalNodeSelection', () => ({
+  useLexicalNodeSelection: () => [false, vi.fn(), vi.fn(), false],
+}));
+
+vi.mock('../ImageEditPopover', () => ({
+  default: ({ children }: { children: ReactNode }) => children,
+}));
+
+vi.mock('../LazyImage', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  function MockLazyImage({
+    newWidth,
+    onLoad,
+  }: {
+    newWidth?: null | number;
+    onLoad?: (dimensions: { height: number; width: number }) => void;
+  }) {
+    React.useEffect(() => {
+      onLoad?.({ height: 100, width: 200 });
+      // The image load event fires once for this regression path.
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return React.createElement('img', {
+      'data-testid': 'image',
+      'style': { width: newWidth ?? 200 },
+    });
+  }
+
+  return {
+    default: MockLazyImage,
+  };
+});
+
+vi.mock('../ResizeHandle', () => ({
+  ResizeHandle: (props: ResizeHandleProps) => {
+    mocks.resizeHandleProps.push(props);
+    return null;
+  },
+}));
+
+describe('Image resize', () => {
+  let host: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+    mocks.resizeHandleProps.length = 0;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    host.remove();
+  });
+
+  it('persists the same width that is previewed during resizing', async () => {
+    const node = {
+      altText: 'test image',
+      getKey: () => 'image-node',
+      getType: () => 'block-image',
+      maxWidth: 200,
+      setMaxWidth: vi.fn(),
+      setWidth: vi.fn(),
+      src: 'https://example.com/image.png',
+      status: 'uploaded',
+      width: 200,
+    };
+
+    await act(async () => {
+      root.render(<Image node={node as any} />);
+    });
+
+    const image = host.querySelector<HTMLImageElement>('[data-testid="image"]');
+    expect(image).not.toBeNull();
+
+    await act(async () => {
+      image!.parentElement!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+
+    const rightHandle = mocks.resizeHandleProps.find((props) => props.position === 'right');
+    expect(rightHandle).toBeDefined();
+
+    await act(async () => {
+      rightHandle!.onResizeStart(100);
+      rightHandle!.onResize(20, 0, 'right');
+    });
+
+    expect(image!.parentElement!.style.width).toBe('140px');
+
+    await act(async () => {
+      rightHandle!.onResizeEnd?.(20, 0);
+    });
+
+    expect(node.setWidth).toHaveBeenCalledWith(140);
+    expect(node.setMaxWidth).toHaveBeenCalledWith(140);
+  });
+});


### PR DESCRIPTION
## Summary
- Unify image resize preview and persistence width calculation.
- Add a regression test for matching previewed width with setWidth/setMaxWidth output.

## Test Plan
- pnpm vitest run src/plugins/image/__test__/litexml.test.ts src/plugins/image/react/components/__tests__/Image.test.tsx
- pnpm type-check

Fixes LOBE-9277