### PR TITLE
🐛 fix(send-button): destructure styles/classNames out of rest props

### DIFF
--- a/src/react/SendButton/SendButton.tsx
+++ b/src/react/SendButton/SendButton.tsx
@@ -24,6 +24,10 @@ const SendButton: FC<SendButtonProps> = ({
   onStop,
   disabled,
   onClick,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  styles: _styles,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  classNames: _classNames,
   ...rest
 }) => {
   const cssVariables = useMemo<Record<string, string>>(


### PR DESCRIPTION
## Summary

- Cherry-picks SendButton CI fix from `feat/blocks` (commit 234b717 by @ilimei) to unblock master CI.
- `SendButtonProps extends DropdownButtonProps`, so `...rest` carries Dropdown-shaped `styles` / `classNames` that conflict with `<Button>`'s own typings.
- Destructures `styles` / `classNames` out of rest so they no longer leak into the spread.

## Why

`type-check` currently fails on master and on every open PR with:

```
src/react/SendButton/SendButton.tsx(38,8): error TS2326: Types of property 'styles' are incompatible.
…(also lines 61, 78, 112)
```

This blocks Test CI and Release CI for unrelated PRs (e.g. #157).

## Test plan

- [x] `npx tsc --noEmit` — no SendButton errors locally
- [x] `npx eslint src/react/SendButton/SendButton.tsx` — clean