### PR TITLE
🐛 fix(editor): expose spellCheck prop, suppress Safari inline predictive text

### DIFF
--- a/src/plugins/common/react/ReactPlainText.tsx
+++ b/src/plugins/common/react/ReactPlainText.tsx
@@ -51,9 +51,7 @@ const ReactPlainText = memo<ReactPlainTextProps>(
     onCompositionEnd,
     onContextMenu,
     onTextChange,
-    // When enablePasteMarkdown is true the editor acts as a rich autocomplete surface;
-    // disabling spellCheck also suppresses Safari/WebKit inline predictive text.
-    spellCheck = !enablePasteMarkdown,
+    spellCheck,
   }) => {
     const isChat = variant === 'chat';
     const {

--- a/src/plugins/common/react/ReactPlainText.tsx
+++ b/src/plugins/common/react/ReactPlainText.tsx
@@ -51,6 +51,9 @@ const ReactPlainText = memo<ReactPlainTextProps>(
     onCompositionEnd,
     onContextMenu,
     onTextChange,
+    // When enablePasteMarkdown is true the editor acts as a rich autocomplete surface;
+    // disabling spellCheck also suppresses Safari/WebKit inline predictive text.
+    spellCheck = !enablePasteMarkdown,
   }) => {
     const isChat = variant === 'chat';
     const {
@@ -243,6 +246,7 @@ const ReactPlainText = memo<ReactPlainTextProps>(
           onContextMenu={handleContextMenu}
           onFocus={handleFocus}
           ref={editorContainerRef}
+          spellCheck={spellCheck}
         />
         <Placeholder lineEmptyPlaceholder={lineEmptyPlaceholder} style={style}>
           {placeholder}

--- a/src/plugins/common/react/type.ts
+++ b/src/plugins/common/react/type.ts
@@ -73,9 +73,8 @@ export interface ReactPlainTextProps {
   pasteVSCodeAsCodeBlock?: boolean;
   /**
    * Controls the spellCheck attribute on the contentEditable div.
-   * When set to false, also suppresses Safari/WebKit inline predictive text.
-   * Defaults to false when enablePasteMarkdown is true (autocomplete scenario),
-   * otherwise follows browser default (true).
+   * Setting to false also suppresses Safari/WebKit inline predictive text (Apple Intelligence).
+   * Consumers that don't want spellcheck (e.g. chat input) should pass spellCheck={false} explicitly.
    */
   spellCheck?: boolean;
   style?: CSSProperties;

--- a/src/plugins/common/react/type.ts
+++ b/src/plugins/common/react/type.ts
@@ -71,6 +71,13 @@ export interface ReactPlainTextProps {
    * @default true
    */
   pasteVSCodeAsCodeBlock?: boolean;
+  /**
+   * Controls the spellCheck attribute on the contentEditable div.
+   * When set to false, also suppresses Safari/WebKit inline predictive text.
+   * Defaults to false when enablePasteMarkdown is true (autocomplete scenario),
+   * otherwise follows browser default (true).
+   */
+  spellCheck?: boolean;
   style?: CSSProperties;
   theme?: CommonPluginOptions['theme'] & {
     fontSize?: number;

--- a/src/react/Editor/demos/spellCheck.tsx
+++ b/src/react/Editor/demos/spellCheck.tsx
@@ -2,7 +2,7 @@ import { Editor, useEditor } from '@lobehub/editor/react';
 import { createStaticStyles } from 'antd-style';
 import { type FC } from 'react';
 
-const useStyles = createStaticStyles(({ css }) => ({
+const styles = createStaticStyles(({ css }) => ({
   container: css`
     display: flex;
     gap: 16px;
@@ -27,7 +27,6 @@ const useStyles = createStaticStyles(({ css }) => ({
 
 const SpellCheckOn: FC = () => {
   const editor = useEditor();
-  const styles = useStyles();
   return (
     <div className={styles.wrapper}>
       <div className={styles.label}>{'spellCheck={true}'} (browser default)</div>
@@ -47,7 +46,6 @@ const SpellCheckOn: FC = () => {
 
 const SpellCheckOff: FC = () => {
   const editor = useEditor();
-  const styles = useStyles();
   return (
     <div className={styles.wrapper}>
       <div className={styles.label}>{'spellCheck={false}'} (recommended for chat input)</div>
@@ -65,7 +63,6 @@ const SpellCheckOff: FC = () => {
 };
 
 const Demo: FC = () => {
-  const styles = useStyles();
   return (
     <div className={styles.container}>
       <SpellCheckOn />

--- a/src/react/Editor/demos/spellCheck.tsx
+++ b/src/react/Editor/demos/spellCheck.tsx
@@ -1,0 +1,78 @@
+import { Editor, useEditor } from '@lobehub/editor/react';
+import { createStaticStyles } from 'antd-style';
+import { type FC } from 'react';
+
+const useStyles = createStaticStyles(({ css, token }) => ({
+  container: css`
+    display: flex;
+    gap: 16px;
+    padding: 16px;
+  `,
+  editor: css`
+    flex: 1;
+    min-height: 120px;
+    padding: 12px;
+    border: 1px solid ${token.colorBorder};
+    border-radius: ${token.borderRadius}px;
+  `,
+  label: css`
+    margin-bottom: 8px;
+    font-size: 12px;
+    font-weight: 500;
+    color: ${token.colorTextSecondary};
+  `,
+  wrapper: css`
+    flex: 1;
+  `,
+}));
+
+const SpellCheckOn: FC = () => {
+  const editor = useEditor();
+  const { styles } = useStyles();
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.label}>spellCheck={'{true}'} (browser default)</div>
+      <Editor
+        autoFocus
+        className={styles.editor}
+        content={''}
+        editor={editor}
+        placeholder={'Type here — browser spellcheck & Safari predictive text active...'}
+        spellCheck={true}
+        type={'text'}
+        variant={'chat'}
+      />
+    </div>
+  );
+};
+
+const SpellCheckOff: FC = () => {
+  const editor = useEditor();
+  const { styles } = useStyles();
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.label}>spellCheck={'{false}'} (recommended for chat input)</div>
+      <Editor
+        className={styles.editor}
+        content={''}
+        editor={editor}
+        placeholder={'Type here — spellcheck & Safari predictive text suppressed...'}
+        spellCheck={false}
+        type={'text'}
+        variant={'chat'}
+      />
+    </div>
+  );
+};
+
+const Demo: FC = () => {
+  const { styles } = useStyles();
+  return (
+    <div className={styles.container}>
+      <SpellCheckOn />
+      <SpellCheckOff />
+    </div>
+  );
+};
+
+export default Demo;

--- a/src/react/Editor/demos/spellCheck.tsx
+++ b/src/react/Editor/demos/spellCheck.tsx
@@ -2,24 +2,23 @@ import { Editor, useEditor } from '@lobehub/editor/react';
 import { createStaticStyles } from 'antd-style';
 import { type FC } from 'react';
 
-const useStyles = createStaticStyles(({ css, token }) => ({
+const useStyles = createStaticStyles(({ css }) => ({
   container: css`
     display: flex;
     gap: 16px;
     padding: 16px;
   `,
   editor: css`
-    flex: 1;
     min-height: 120px;
     padding: 12px;
-    border: 1px solid ${token.colorBorder};
-    border-radius: ${token.borderRadius}px;
+    border: 1px solid #d9d9d9;
+    border-radius: 6px;
   `,
   label: css`
     margin-bottom: 8px;
     font-size: 12px;
     font-weight: 500;
-    color: ${token.colorTextSecondary};
+    opacity: 0.6;
   `,
   wrapper: css`
     flex: 1;
@@ -28,10 +27,10 @@ const useStyles = createStaticStyles(({ css, token }) => ({
 
 const SpellCheckOn: FC = () => {
   const editor = useEditor();
-  const { styles } = useStyles();
+  const styles = useStyles();
   return (
     <div className={styles.wrapper}>
-      <div className={styles.label}>spellCheck={'{true}'} (browser default)</div>
+      <div className={styles.label}>{'spellCheck={true}'} (browser default)</div>
       <Editor
         autoFocus
         className={styles.editor}
@@ -48,10 +47,10 @@ const SpellCheckOn: FC = () => {
 
 const SpellCheckOff: FC = () => {
   const editor = useEditor();
-  const { styles } = useStyles();
+  const styles = useStyles();
   return (
     <div className={styles.wrapper}>
-      <div className={styles.label}>spellCheck={'{false}'} (recommended for chat input)</div>
+      <div className={styles.label}>{'spellCheck={false}'} (recommended for chat input)</div>
       <Editor
         className={styles.editor}
         content={''}
@@ -66,7 +65,7 @@ const SpellCheckOff: FC = () => {
 };
 
 const Demo: FC = () => {
-  const { styles } = useStyles();
+  const styles = useStyles();
   return (
     <div className={styles.container}>
       <SpellCheckOn />

--- a/src/react/Editor/index.md
+++ b/src/react/Editor/index.md
@@ -38,6 +38,15 @@ Force all pasted content to be inserted as plain text, stripping any rich text f
 
 <code src="./demos/pasteAsPlainText.tsx" nopadding iframe></code>
 
+
+## spellCheck — Suppress Safari Inline Predictive Text
+
+Setting `spellCheck={false}` on the editor disables OS-level spellcheck and suppresses
+Safari/WebKit inline predictive text (Apple Intelligence). This is recommended for chat
+input surfaces where the editor provides its own autocomplete.
+
+<code src="./demos/spellCheck.tsx" nopadding></code>
+
 ## APIs
 
 ### Editor


### PR DESCRIPTION
## Problem

Safari 18+ (macOS Sequoia) enables inline predictive text by default on all `contenteditable` elements. The `ReactPlainText` component rendered a bare `contentEditable` div with no `spellCheck` attribute, causing Safari's Apple Intelligence text predictions to appear inside the chat input.

## Changes

### `src/plugins/common/react/type.ts`
- Added `spellCheck?: boolean` to `ReactPlainTextProps` with JSDoc explaining the Safari/WebKit behavior.

### `src/plugins/common/react/ReactPlainText.tsx`
- Accept `spellCheck` prop and forward it to the inner `contentEditable` div.
- Default value: `!enablePasteMarkdown`
  - When `enablePasteMarkdown` is `true` (default, chat input), `spellCheck` defaults to `false` → suppresses Safari predictive text.
  - When `enablePasteMarkdown` is `false` (plain text mode, e.g. pure code editor), `spellCheck` defaults to `true` → normal browser spellcheck.
  - Callers can always override explicitly.

### `src/react/Editor/Editor.tsx`
- No change needed — `EditorProps` already `extends Omit<ReactPlainTextProps, 'children'>`, so `spellCheck` is automatically part of the public API.

## Why `spellCheck={false}` fixes it

Per [WebKit commit 2d67e9c](https://github.com/WebKit/WebKit/commit/2d67e9cb94d7b6a8fa75ca87c72ca437752e0199), setting `spellcheck=false` on a `contentEditable` element also suppresses platform-level spellchecking and inline text prediction in Safari. This is the most reliable and standards-compliant approach — `autocomplete` attributes have no effect on `contenteditable` divs.