### PR TITLE
✨ feat(content-blocks): add plugin for extracting AI message content blocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ export * from './plugins/code';
 export * from './plugins/codeblock';
 export * from './plugins/codemirror-block';
 export * from './plugins/common';
+export * from './plugins/content-blocks';
 export * from './plugins/file';
 export * from './plugins/hr';
 export * from './plugins/image';

--- a/src/plugins/content-blocks/data-source/content-blocks-data-source.ts
+++ b/src/plugins/content-blocks/data-source/content-blocks-data-source.ts
@@ -1,0 +1,31 @@
+import type { LexicalEditor } from 'lexical';
+
+import { DataSource } from '@/editor-kernel';
+import type { IMarkdownShortCutService } from '@/plugins/markdown/service/shortcut';
+
+import type { ContentBlock, ExtractContentBlocksOptions } from '../types';
+import { CONTENT_BLOCKS_DATA_TYPE } from '../types';
+import { extractContentBlocks } from '../utils/extract';
+
+export class ContentBlocksDataSource extends DataSource {
+  constructor(
+    private getMarkdownService: () => IMarkdownShortCutService | null,
+    private defaultOptions: ExtractContentBlocksOptions = {},
+  ) {
+    super(CONTENT_BLOCKS_DATA_TYPE);
+  }
+
+  override read(): void {
+    throw new Error("'content-blocks' data source is write-only (editor → blocks).");
+  }
+
+  override write(editor: LexicalEditor): ContentBlock[] {
+    const service = this.getMarkdownService();
+    if (!service) {
+      throw new Error(
+        'ContentBlocksPlugin requires MarkdownPlugin to be registered first; markdown writer service is missing.',
+      );
+    }
+    return extractContentBlocks(editor, service, this.defaultOptions);
+  }
+}

--- a/src/plugins/content-blocks/demos/data.json
+++ b/src/plugins/content-blocks/demos/data.json
@@ -1,0 +1,81 @@
+{
+  "root": {
+    "children": [
+      {
+        "children": [
+          {
+            "detail": 0,
+            "format": 0,
+            "mode": "normal",
+            "style": "",
+            "text": "Tell me what's in this picture: ",
+            "type": "text",
+            "version": 1
+          },
+          {
+            "type": "image",
+            "version": 1,
+            "altText": "avatar.png",
+            "caption": {
+              "editorState": {
+                "root": {
+                  "children": [],
+                  "direction": null,
+                  "format": "",
+                  "indent": 0,
+                  "type": "root",
+                  "version": 1
+                }
+              }
+            },
+            "height": 0,
+            "maxWidth": 320,
+            "showCaption": false,
+            "src": "https://avatars.githubusercontent.com/u/17870709?v=4",
+            "status": "uploaded",
+            "width": 0
+          },
+          {
+            "detail": 0,
+            "format": 0,
+            "mode": "normal",
+            "style": "",
+            "text": " — and reference the file below.",
+            "type": "text",
+            "version": 1
+          }
+        ],
+        "direction": null,
+        "format": "",
+        "indent": 0,
+        "type": "paragraph",
+        "version": 1,
+        "textFormat": 0,
+        "textStyle": ""
+      },
+      {
+        "altText": "Block image example",
+        "height": 240,
+        "maxWidth": 480,
+        "src": "https://images.unsplash.com/photo-1469474968028-56623f02e42e?w=640",
+        "status": "uploaded",
+        "type": "block-image",
+        "version": 1,
+        "width": 480
+      },
+      {
+        "type": "file",
+        "version": 1,
+        "fileUrl": "https://example.com/spec.pdf",
+        "name": "spec.pdf",
+        "size": 20480,
+        "status": "uploaded"
+      }
+    ],
+    "direction": null,
+    "format": "",
+    "indent": 0,
+    "type": "root",
+    "version": 1
+  }
+}

--- a/src/plugins/content-blocks/demos/headless.tsx
+++ b/src/plugins/content-blocks/demos/headless.tsx
@@ -1,0 +1,124 @@
+'use client';
+
+import {
+  CONTENT_BLOCKS_DATA_TYPE,
+  type ContentBlock,
+  ContentBlocksPlugin,
+  FilePlugin,
+  ImagePlugin,
+  type MediaLists,
+  extractMediaLists,
+} from '@lobehub/editor';
+import { DEFAULT_HEADLESS_EDITOR_PLUGINS, createHeadlessEditor } from '@lobehub/editor/headless';
+import { CodeEditor, Collapse, Highlighter } from '@lobehub/ui';
+import { debounce } from 'es-toolkit';
+import { useMemo, useState } from 'react';
+
+import sample from './data.json';
+
+const noopUpload = async (): Promise<{ url: string }> => ({ url: '' });
+
+const buildHeadless = () =>
+  createHeadlessEditor({
+    additionalPlugins: [
+      [ImagePlugin, { handleUpload: noopUpload, renderImage: () => null }],
+      [FilePlugin, { decorator: () => null, handleUpload: noopUpload }],
+      ContentBlocksPlugin,
+    ],
+    plugins: DEFAULT_HEADLESS_EDITOR_PLUGINS,
+  });
+
+interface Result {
+  blocks: ContentBlock[];
+  error?: string;
+  media: MediaLists;
+}
+
+const extract = (jsonText: string): Result => {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonText);
+  } catch (error) {
+    return {
+      blocks: [],
+      error: `Invalid JSON: ${(error as Error).message}`,
+      media: { fileList: [], imageList: [] },
+    };
+  }
+
+  const headless = buildHeadless();
+  try {
+    headless.hydrate({ content: parsed, type: 'json' });
+    const blocks = headless.kernel.getDocument(
+      CONTENT_BLOCKS_DATA_TYPE,
+    ) as unknown as ContentBlock[];
+    return { blocks: blocks ?? [], media: extractMediaLists(blocks ?? []) };
+  } catch (error) {
+    return {
+      blocks: [],
+      error: (error as Error).message,
+      media: { fileList: [], imageList: [] },
+    };
+  } finally {
+    headless.destroy();
+  }
+};
+
+const initialInput = JSON.stringify(sample, null, 2);
+
+export default () => {
+  const [input, setInput] = useState(initialInput);
+  const [result, setResult] = useState<Result>(() => extract(initialInput));
+
+  const debouncedExtract = useMemo(
+    () => debounce((value: string) => setResult(extract(value)), 200),
+    [],
+  );
+
+  const handleChange = (next: string) => {
+    setInput(next);
+    debouncedExtract(next);
+  };
+
+  return (
+    <Collapse
+      defaultActiveKey={['input', 'blocks', 'media']}
+      items={[
+        {
+          children: (
+            <CodeEditor
+              language="json"
+              onValueChange={handleChange}
+              style={{ fontSize: 12 }}
+              value={input}
+              variant="borderless"
+            />
+          ),
+          key: 'input',
+          label: 'Editor JSON (input)',
+        },
+        {
+          children: (
+            <Highlighter language="json" style={{ fontSize: 12, padding: 16 }} variant="borderless">
+              {result.error ? `// ${result.error}` : JSON.stringify(result.blocks, null, 2)}
+            </Highlighter>
+          ),
+          key: 'blocks',
+          label: `content-blocks (${result.blocks.length})`,
+        },
+        {
+          children: (
+            <Highlighter language="json" style={{ fontSize: 12, padding: 16 }} variant="borderless">
+              {JSON.stringify(result.media, null, 2)}
+            </Highlighter>
+          ),
+          key: 'media',
+          label: `extractMediaLists → ${result.media.imageList.length} image · ${result.media.fileList.length} file`,
+        },
+      ]}
+      padding={{ body: 0 }}
+      style={{ border: 'none', borderRadius: 0, width: '100%' }}
+      variant="outlined"
+    />
+  );
+};

--- a/src/plugins/content-blocks/demos/headless.tsx
+++ b/src/plugins/content-blocks/demos/headless.tsx
@@ -9,10 +9,11 @@ import {
   type MediaLists,
   extractMediaLists,
 } from '@lobehub/editor';
-import { DEFAULT_HEADLESS_EDITOR_PLUGINS, createHeadlessEditor } from '@lobehub/editor/headless';
 import { CodeEditor, Collapse, Highlighter } from '@lobehub/ui';
 import { debounce } from 'es-toolkit';
 import { useMemo, useState } from 'react';
+
+import { DEFAULT_HEADLESS_EDITOR_PLUGINS, createHeadlessEditor } from '@/headless';
 
 import sample from './data.json';
 

--- a/src/plugins/content-blocks/demos/index.tsx
+++ b/src/plugins/content-blocks/demos/index.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import {
+  CONTENT_BLOCKS_DATA_TYPE,
+  type ContentBlock,
+  ContentBlocksPlugin,
+  type IEditor,
+  type MediaLists,
+  ReactFilePlugin,
+  ReactImagePlugin,
+  extractMediaLists,
+} from '@lobehub/editor';
+import { Editor, useEditor } from '@lobehub/editor/react';
+import { Collapse, Highlighter, ToastHost } from '@lobehub/ui';
+import { debounce } from 'es-toolkit';
+import { type FC, useLayoutEffect, useMemo, useState } from 'react';
+
+import { useLexicalComposerContext } from '@/editor-kernel/react';
+
+import content from './data.json';
+
+const ReactContentBlocksPlugin: FC = () => {
+  const [editor] = useLexicalComposerContext();
+  useLayoutEffect(() => {
+    editor.registerPlugin(ContentBlocksPlugin);
+  }, [editor]);
+  return null;
+};
+
+const Panel: FC<{ value: unknown }> = ({ value }) => (
+  <Highlighter language="json" style={{ fontSize: 12, padding: 16 }} variant="borderless">
+    {JSON.stringify(value, null, 2)}
+  </Highlighter>
+);
+
+const emptyMedia: MediaLists = { fileList: [], imageList: [] };
+
+const fileUpload = async (file: File): Promise<{ url: string }> =>
+  new Promise((resolve) => {
+    setTimeout(() => resolve({ url: URL.createObjectURL(file) }), 600);
+  });
+
+export default () => {
+  const editor = useEditor();
+  const [blocks, setBlocks] = useState<ContentBlock[]>([]);
+  const [media, setMedia] = useState<MediaLists>(emptyMedia);
+
+  const handleChange = useMemo(
+    () =>
+      debounce((ed: IEditor) => {
+        try {
+          const next = ed.getDocument(CONTENT_BLOCKS_DATA_TYPE) as unknown as ContentBlock[];
+          setBlocks(next ?? []);
+          setMedia(extractMediaLists(next ?? []));
+        } catch (error) {
+          console.error('[content-blocks demo]', error);
+        }
+      }, 150),
+    [],
+  );
+
+  return (
+    <>
+      <ToastHost />
+      <Collapse
+        defaultActiveKey={['editor', 'blocks', 'media']}
+        items={[
+          {
+            children: (
+              <Editor
+                content={content}
+                editor={editor}
+                onInit={handleChange}
+                onTextChange={handleChange}
+                placeholder="Edit text · drop images · attach files…"
+                plugins={[
+                  ReactContentBlocksPlugin,
+                  Editor.withProps(ReactImagePlugin, { defaultBlockImage: true }),
+                  Editor.withProps(ReactFilePlugin, { handleUpload: fileUpload }),
+                ]}
+                style={{ padding: 16 }}
+                type="json"
+              />
+            ),
+            key: 'editor',
+            label: 'Playground',
+          },
+          {
+            children: <Panel value={blocks} />,
+            key: 'blocks',
+            label: `content-blocks (${blocks.length})`,
+          },
+          {
+            children: <Panel value={media} />,
+            key: 'media',
+            label: `extractMediaLists → ${media.imageList.length} image · ${media.fileList.length} file`,
+          },
+        ]}
+        padding={{ body: 0 }}
+        style={{ border: 'none', borderRadius: 0, width: '100%' }}
+        variant="outlined"
+      />
+    </>
+  );
+};

--- a/src/plugins/content-blocks/index.md
+++ b/src/plugins/content-blocks/index.md
@@ -11,6 +11,12 @@ description: Content Blocks plugin extracts the current editor state into discre
 
 The plugin requires `MarkdownPlugin` to be registered first, since text serialization reuses the markdown writer.
 
+## Playground
+
+Edit the editor below and watch the extracted `ContentBlock[]` and derived `imageList` / `fileList` update live.
+
+<code src="./demos/index.tsx"></code>
+
 ## Quick Start
 
 ### Register
@@ -54,6 +60,40 @@ const { imageList, fileList } = extractMediaLists(blocks);
 ```
 
 `extractMediaLists` is a pure transformation over `ContentBlock[]` — no editor or service required. It scans the blocks once, ignores `text` parts, and produces the two media arrays in document order with fresh ids per entry.
+
+## Headless Usage
+
+`ContentBlocksPlugin` works without any DOM — pair it with the headless editor to extract blocks from a persisted editor state (typically server-side or inside a worker).
+
+```ts
+import {
+  CONTENT_BLOCKS_DATA_TYPE,
+  type ContentBlock,
+  ContentBlocksPlugin,
+  FilePlugin,
+  ImagePlugin,
+} from '@lobehub/editor';
+import { DEFAULT_HEADLESS_EDITOR_PLUGINS, createHeadlessEditor } from '@lobehub/editor/headless';
+
+const headless = createHeadlessEditor({
+  additionalPlugins: [
+    [ImagePlugin, { renderImage: () => null, handleUpload: async () => ({ url: '' }) }],
+    [FilePlugin, { decorator: () => null, handleUpload: async () => ({ url: '' }) }],
+    ContentBlocksPlugin,
+  ],
+  plugins: DEFAULT_HEADLESS_EDITOR_PLUGINS,
+});
+
+headless.hydrate({ content: editorJson, type: 'json' });
+const blocks = headless.kernel.getDocument(CONTENT_BLOCKS_DATA_TYPE) as unknown as ContentBlock[];
+headless.destroy();
+```
+
+`ImagePlugin` and `FilePlugin` are registered with no-op render / upload callbacks because the headless editor never touches the DOM. `MarkdownPlugin` is already part of `DEFAULT_HEADLESS_EDITOR_PLUGINS`, satisfying the markdown-writer dependency.
+
+Edit the JSON input below and watch the headless extraction run live:
+
+<code src="./demos/headless.tsx"></code>
 
 ## ContentBlock Schema
 

--- a/src/plugins/content-blocks/index.md
+++ b/src/plugins/content-blocks/index.md
@@ -1,0 +1,233 @@
+---
+nav: Plugins
+group: Plugins
+title: Content Blocks
+description: Content Blocks plugin extracts the current editor state into discrete content blocks (text / image / file) suitable for downstream AI chat pipelines. It mirrors the message-part format used by lobe-chat's context engine and ships a small helper to derive `imageList` / `fileList` arrays from the blocks.
+---
+
+## Introduction
+
+`ContentBlocksPlugin` is a write-only utility plugin. It does not render anything in the editor; it observes the current Lexical state and produces a structured representation that AI chat backends can consume.
+
+The plugin requires `MarkdownPlugin` to be registered first, since text serialization reuses the markdown writer.
+
+## Quick Start
+
+### Register
+
+```ts
+import Editor from '@lobehub/editor';
+import {
+  CommonPlugin,
+  ContentBlocksPlugin,
+  FilePlugin,
+  ImagePlugin,
+  MarkdownPlugin,
+} from '@lobehub/editor/plugins';
+
+const kernel = Editor.createEditor().registerPlugins([
+  CommonPlugin,
+  MarkdownPlugin,
+  [ImagePlugin, { renderImage: () => null }],
+  [FilePlugin, { decorator: () => null, handleUpload }],
+  ContentBlocksPlugin,
+]);
+kernel.initNodeEditor();
+```
+
+### Extract blocks
+
+```ts
+import type { ContentBlock } from '@lobehub/editor/plugins';
+
+const blocks = kernel.getDocument('content-blocks') as ContentBlock[];
+```
+
+The `content-blocks` data source is write-only — `kernel.setDocument('content-blocks', ...)` is not supported.
+
+### Derive imageList / fileList from blocks
+
+```ts
+import { extractMediaLists } from '@lobehub/editor/plugins';
+
+const { imageList, fileList } = extractMediaLists(blocks);
+```
+
+`extractMediaLists` is a pure transformation over `ContentBlock[]` — no editor or service required. It scans the blocks once, ignores `text` parts, and produces the two media arrays in document order with fresh ids per entry.
+
+## ContentBlock Schema
+
+```ts
+type ContentBlock =
+  | { type: 'text'; text: string }
+  | { type: 'image'; url: string; alt: string; width?: number; height?: number }
+  | { type: 'file'; url: string; name: string; size?: number };
+```
+
+- Text parts hold markdown serialized from the surrounding text run.
+- Image and file parts are emitted **only** when the underlying node's status is `uploaded`. Non-uploaded nodes become text placeholders (configurable — see [Plugin Options](#plugin-options)).
+- `width` / `height` are omitted when the image stores `'inherit'` or `0`.
+- Adjacent text parts are merged with `\n\n` separators after extraction.
+
+## Extraction Behavior
+
+### Node-to-block mapping
+
+| Lexical node type                             | Emitted as                               |
+| --------------------------------------------- | ---------------------------------------- |
+| `image` (inline)                              | Image block (lifted out of its parent)   |
+| `block-image`                                 | Image block                              |
+| `file`                                        | File block                               |
+| `paragraph` / `heading` / `quote` (text-only) | Part of a text block                     |
+| Other elements (list, table, code, …)         | Serialized as markdown into a text block |
+
+### Container splitting
+
+Paragraphs, headings, and quotes that contain inline images are **split** around each image:
+
+```text
+Paragraph [ "before " <image src=A> " after" ]
+  →  text("before") + image(A) + text("after")
+```
+
+Non-splittable containers (lists, tables, code blocks) keep their inline images inline — the markdown writer renders them as `![alt](src)` within the text block.
+
+### Root-level atomics
+
+Image and file nodes placed directly under the editor root are always emitted as standalone blocks, regardless of any `isInline()` declaration on the node class.
+
+### Upload status & placeholders
+
+For an image or file that is not yet `uploaded`, the default behavior is to flush a textual placeholder into the surrounding text block:
+
+| Status    | Placeholder                                                            |
+| --------- | ---------------------------------------------------------------------- |
+| `loading` | `[image uploading...]`                                                 |
+| `pending` | `[file uploading: <name>]`                                             |
+| `error`   | `[image upload failed: <msg>]` / `[file upload failed: <name>: <msg>]` |
+
+Setting `emitPlaceholderForUnuploaded: false` drops the node silently. Surrounding text on both sides will then merge into a single text block.
+
+### Text-block merging
+
+After all nodes are visited, adjacent text blocks are concatenated with `\n\n`. This keeps `imageList` / `fileList` accurate when derived later, while preventing fragmented text output.
+
+## Direct API
+
+The plugin's logic is also exposed as plain functions for callers that already hold a `LexicalEditor` reference.
+
+### `extractContentBlocks`
+
+```ts
+import {
+  type ContentBlock,
+  type ExtractContentBlocksOptions,
+  extractContentBlocks,
+} from '@lobehub/editor/plugins';
+import { IMarkdownShortCutService } from '@lobehub/editor/plugins/markdown/service/shortcut';
+
+const editor = kernel.getLexicalEditor()!;
+const service = kernel.requireService(IMarkdownShortCutService)!;
+
+const blocks: ContentBlock[] = extractContentBlocks(editor, service, {
+  emitPlaceholderForUnuploaded: false,
+});
+```
+
+### `extractMediaLists`
+
+```ts
+import { type MediaLists, extractMediaLists } from '@lobehub/editor/plugins';
+
+const { imageList, fileList }: MediaLists = extractMediaLists(blocks);
+```
+
+Returns:
+
+| Field       | Description                                                                                  |
+| ----------- | -------------------------------------------------------------------------------------------- |
+| `imageList` | `{ id, alt, url }[]` — one entry per image block, in document order.                         |
+| `fileList`  | `{ id, name, size, fileType, url }[]` — one entry per file block. `fileType` from extension. |
+
+## Plugin Options
+
+### `ContentBlocksPluginOptions`
+
+| Property         | Description                                                                                                                                                             | Type                          | Default |
+| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------- | ------- |
+| `defaultOptions` | Default `ExtractContentBlocksOptions` applied when reading via `kernel.getDocument('content-blocks')`. Direct callers of `extractContentBlocks` pass their own options. | `ExtractContentBlocksOptions` | `{}`    |
+
+### `ExtractContentBlocksOptions`
+
+| Property                       | Description                                                                                      | Type      | Default |
+| ------------------------------ | ------------------------------------------------------------------------------------------------ | --------- | ------- |
+| `emitPlaceholderForUnuploaded` | When `true`, non-uploaded images/files become text placeholders. When `false`, dropped silently. | `boolean` | `true`  |
+
+### Example: silent drop
+
+```ts
+const kernel = Editor.createEditor().registerPlugins([
+  CommonPlugin,
+  MarkdownPlugin,
+  ImagePlugin,
+  FilePlugin,
+  [ContentBlocksPlugin, { defaultOptions: { emitPlaceholderForUnuploaded: false } }],
+]);
+```
+
+## Type Reference
+
+```ts
+export const CONTENT_BLOCKS_DATA_TYPE = 'content-blocks';
+
+export interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+export interface ImageContentBlock {
+  type: 'image';
+  url: string;
+  alt: string;
+  width?: number;
+  height?: number;
+}
+
+export interface FileContentBlock {
+  type: 'file';
+  url: string;
+  name: string;
+  size?: number;
+}
+
+export type ContentBlock = TextContentBlock | ImageContentBlock | FileContentBlock;
+
+export interface ImageListItem {
+  id: string;
+  alt: string;
+  url: string;
+}
+
+export interface FileListItem {
+  id: string;
+  name: string;
+  size: number;
+  fileType: string;
+  url: string;
+}
+
+export interface MediaLists {
+  imageList: ImageListItem[];
+  fileList: FileListItem[];
+}
+
+export interface ExtractContentBlocksOptions {
+  emitPlaceholderForUnuploaded?: boolean;
+}
+```
+
+## Notes
+
+- The plugin only writes; it does not introduce nodes, decorators, or commands into the editor.
+- `MarkdownPlugin` must be registered before `ContentBlocksPlugin`. If absent, a warning is logged on init and `kernel.getDocument('content-blocks')` throws.
+- Image and file detection relies on the standard node types `image`, `block-image`, and `file` shipped with `ImagePlugin` / `FilePlugin`. Custom atomic node types are not currently recognized.

--- a/src/plugins/content-blocks/index.ts
+++ b/src/plugins/content-blocks/index.ts
@@ -1,0 +1,16 @@
+export { ContentBlocksDataSource } from './data-source/content-blocks-data-source';
+export type { ContentBlocksPluginOptions } from './plugin';
+export { ContentBlocksPlugin } from './plugin';
+export type {
+  ContentBlock,
+  ExtractContentBlocksOptions,
+  FileContentBlock,
+  FileListItem,
+  ImageContentBlock,
+  ImageListItem,
+  MediaLists,
+  TextContentBlock,
+} from './types';
+export { CONTENT_BLOCKS_DATA_TYPE } from './types';
+export { extractContentBlocks } from './utils/extract';
+export { extractMediaLists } from './utils/extract-media-lists';

--- a/src/plugins/content-blocks/plugin/index.ts
+++ b/src/plugins/content-blocks/plugin/index.ts
@@ -1,0 +1,40 @@
+import { KernelPlugin } from '@/editor-kernel/plugin';
+import { IMarkdownShortCutService } from '@/plugins/markdown/service/shortcut';
+import type { IEditorKernel, IEditorPlugin, IEditorPluginConstructor } from '@/types';
+import { createDebugLogger } from '@/utils/debug';
+
+import { ContentBlocksDataSource } from '../data-source/content-blocks-data-source';
+import type { ExtractContentBlocksOptions } from '../types';
+
+export interface ContentBlocksPluginOptions {
+  defaultOptions?: ExtractContentBlocksOptions;
+}
+
+export const ContentBlocksPlugin: IEditorPluginConstructor<ContentBlocksPluginOptions> = class
+  extends KernelPlugin
+  implements IEditorPlugin<ContentBlocksPluginOptions>
+{
+  static pluginName = 'ContentBlocksPlugin';
+  private logger = createDebugLogger('plugin', 'content-blocks');
+
+  constructor(
+    protected kernel: IEditorKernel,
+    public config?: ContentBlocksPluginOptions,
+  ) {
+    super();
+    kernel.registerDataSource(
+      new ContentBlocksDataSource(
+        () => kernel.requireService(IMarkdownShortCutService),
+        config?.defaultOptions,
+      ),
+    );
+  }
+
+  onInit(): void {
+    if (!this.kernel.requireService(IMarkdownShortCutService)) {
+      this.logger.warn(
+        'MarkdownPlugin is not registered; content-blocks extraction will throw on demand.',
+      );
+    }
+  }
+};

--- a/src/plugins/content-blocks/types.ts
+++ b/src/plugins/content-blocks/types.ts
@@ -1,0 +1,52 @@
+export interface TextContentBlock {
+  text: string;
+  type: 'text';
+}
+
+export interface ImageContentBlock {
+  alt: string;
+  height?: number;
+  type: 'image';
+  url: string;
+  width?: number;
+}
+
+export interface FileContentBlock {
+  name: string;
+  size?: number;
+  type: 'file';
+  url: string;
+}
+
+export type ContentBlock = TextContentBlock | ImageContentBlock | FileContentBlock;
+
+export interface ExtractContentBlocksOptions {
+  /**
+   * When an image/file is in `loading` / `pending` / `error` state and thus has no
+   * usable URL, emit a textual placeholder into the surrounding text block instead
+   * of dropping the node silently.
+   * @default true
+   */
+  emitPlaceholderForUnuploaded?: boolean;
+}
+
+export interface ImageListItem {
+  alt: string;
+  id: string;
+  url: string;
+}
+
+export interface FileListItem {
+  fileType: string;
+  id: string;
+  name: string;
+  size: number;
+  url: string;
+}
+
+export interface MediaLists {
+  fileList: FileListItem[];
+  imageList: ImageListItem[];
+}
+
+export const CONTENT_BLOCKS_DATA_TYPE = 'content-blocks';

--- a/src/plugins/content-blocks/utils/__tests__/extract-media-lists.test.ts
+++ b/src/plugins/content-blocks/utils/__tests__/extract-media-lists.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+
+import { extractMediaLists } from '../extract-media-lists';
+
+describe('extractMediaLists', () => {
+  it('returns empty lists for empty input', () => {
+    expect(extractMediaLists([])).toEqual({ fileList: [], imageList: [] });
+  });
+
+  it('ignores text blocks', () => {
+    const lists = extractMediaLists([
+      { text: 'hello', type: 'text' },
+      { text: 'world', type: 'text' },
+    ]);
+    expect(lists.imageList).toEqual([]);
+    expect(lists.fileList).toEqual([]);
+  });
+
+  it('collects images in order', () => {
+    const lists = extractMediaLists([
+      { alt: 'a', type: 'image', url: 'https://cdn/a.png' },
+      { text: 'mid', type: 'text' },
+      { alt: 'b', type: 'image', url: 'https://cdn/b.png' },
+    ]);
+    expect(lists.imageList).toHaveLength(2);
+    expect(lists.imageList[0]).toMatchObject({ alt: 'a', url: 'https://cdn/a.png' });
+    expect(lists.imageList[1]).toMatchObject({ alt: 'b', url: 'https://cdn/b.png' });
+    expect(lists.imageList[0].id).toEqual(expect.any(String));
+  });
+
+  it('collects files with fileType inferred from extension', () => {
+    const lists = extractMediaLists([
+      { name: 'report.pdf', size: 1024, type: 'file', url: 'https://cdn/x.pdf' },
+      { name: 'photo.PNG', type: 'file', url: 'https://cdn/y.png' },
+      { name: 'noext', type: 'file', url: 'https://cdn/z' },
+    ]);
+    expect(lists.fileList[0].fileType).toBe('pdf');
+    expect(lists.fileList[0].size).toBe(1024);
+    expect(lists.fileList[1].fileType).toBe('png');
+    expect(lists.fileList[2].fileType).toBe('unknown');
+    expect(lists.fileList[2].size).toBe(0);
+  });
+
+  it('generates unique ids per entry', () => {
+    const lists = extractMediaLists([
+      { alt: '', type: 'image', url: 'a' },
+      { alt: '', type: 'image', url: 'b' },
+      { name: 'a.txt', type: 'file', url: 'fa' },
+      { name: 'b.txt', type: 'file', url: 'fb' },
+    ]);
+    const ids = [
+      lists.imageList[0].id,
+      lists.imageList[1].id,
+      lists.fileList[0].id,
+      lists.fileList[1].id,
+    ];
+    expect(new Set(ids).size).toBe(4);
+  });
+});

--- a/src/plugins/content-blocks/utils/__tests__/extract.test.ts
+++ b/src/plugins/content-blocks/utils/__tests__/extract.test.ts
@@ -1,0 +1,274 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import type { IEditor } from '@/types';
+
+import { CommonPlugin } from '../../../common';
+import { FilePlugin } from '../../../file';
+import { ImagePlugin } from '../../../image';
+import { MarkdownPlugin } from '../../../markdown/plugin';
+import { IMarkdownShortCutService } from '../../../markdown/service/shortcut';
+import { ContentBlocksPlugin } from '../../plugin';
+import { CONTENT_BLOCKS_DATA_TYPE, type ContentBlock } from '../../types';
+import { extractContentBlocks } from '../extract';
+
+const buildKernel = (): IEditor => {
+  const kernel = Editor.createEditor().registerPlugins([
+    CommonPlugin,
+    MarkdownPlugin,
+    [ImagePlugin, { renderImage: () => null }],
+    [FilePlugin, { decorator: () => null, handleUpload: async () => ({ url: '' }) }],
+    ContentBlocksPlugin,
+  ]);
+  kernel.initNodeEditor();
+  return kernel;
+};
+
+const seed = (kernel: IEditor, root: Record<string, unknown>) => {
+  kernel.setDocument('json', { root }, { keepId: true });
+};
+
+const getBlocks = (kernel: IEditor): ContentBlock[] =>
+  kernel.getDocument(CONTENT_BLOCKS_DATA_TYPE) as unknown as ContentBlock[];
+
+const paragraphRoot = (children: Record<string, unknown>[]) => ({
+  children,
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  type: 'root',
+  version: 1,
+});
+
+const paragraph = (children: Record<string, unknown>[]) => ({
+  children,
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  textFormat: 0,
+  textStyle: '',
+  type: 'paragraph',
+  version: 1,
+});
+
+const textNode = (text: string) => ({
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  style: '',
+  text,
+  type: 'text',
+  version: 1,
+});
+
+const inlineImage = (
+  attrs: Partial<{
+    altText: string;
+    height: number;
+    maxWidth: number;
+    src: string;
+    status: 'uploaded' | 'loading' | 'error';
+    width: number;
+  }>,
+) => ({
+  altText: '',
+  height: 0,
+  maxWidth: 500,
+  src: '',
+  status: 'uploaded',
+  type: 'image',
+  version: 1,
+  width: 0,
+  ...attrs,
+});
+
+const blockImage = (
+  attrs: Partial<{
+    altText: string;
+    height: number;
+    maxWidth: number;
+    src: string;
+    status: 'uploaded' | 'loading' | 'error';
+    width: number;
+  }>,
+) => ({
+  altText: '',
+  height: 0,
+  maxWidth: 500,
+  src: '',
+  status: 'uploaded',
+  type: 'block-image',
+  version: 1,
+  width: 0,
+  ...attrs,
+});
+
+const fileNode = (
+  attrs: Partial<{
+    fileUrl: string;
+    message: string;
+    name: string;
+    size: number;
+    status: 'pending' | 'uploaded' | 'error';
+  }>,
+) => ({
+  name: 'unknown',
+  status: 'pending',
+  type: 'file',
+  version: 1,
+  ...attrs,
+});
+
+describe('extractContentBlocks', () => {
+  let kernel: IEditor;
+
+  beforeEach(() => {
+    kernel = buildKernel();
+  });
+
+  it('returns an empty array for an empty editor', () => {
+    seed(kernel, paragraphRoot([paragraph([])]));
+    expect(getBlocks(kernel)).toEqual([]);
+  });
+
+  it('returns a single text block for plain paragraphs', () => {
+    seed(kernel, paragraphRoot([paragraph([textNode('Hello world')])]));
+    const blocks = getBlocks(kernel);
+    expect(blocks).toEqual([{ text: 'Hello world', type: 'text' }]);
+  });
+
+  it('emits a stand-alone image block for a root-level block image', () => {
+    seed(kernel, paragraphRoot([blockImage({ altText: 'logo', src: 'https://cdn/logo.png' })]));
+    expect(getBlocks(kernel)).toEqual([
+      { alt: 'logo', type: 'image', url: 'https://cdn/logo.png' },
+    ]);
+  });
+
+  it('splits a paragraph around an inline image', () => {
+    seed(
+      kernel,
+      paragraphRoot([
+        paragraph([
+          textNode('before '),
+          inlineImage({ altText: 'pic', src: 'https://cdn/a.png' }),
+          textNode(' after'),
+        ]),
+      ]),
+    );
+    const blocks = getBlocks(kernel);
+    expect(blocks).toHaveLength(3);
+    expect(blocks[0]).toEqual({ text: 'before', type: 'text' });
+    expect(blocks[1]).toEqual({ alt: 'pic', type: 'image', url: 'https://cdn/a.png' });
+    expect(blocks[2]).toEqual({ text: 'after', type: 'text' });
+  });
+
+  it('emits image and file blocks in document order', () => {
+    seed(
+      kernel,
+      paragraphRoot([
+        paragraph([textNode('hi')]),
+        blockImage({ altText: 'a', src: 'https://cdn/a.png' }),
+        fileNode({
+          fileUrl: 'https://cdn/x.pdf',
+          name: 'x.pdf',
+          size: 1234,
+          status: 'uploaded',
+        }),
+        paragraph([textNode('end')]),
+      ]),
+    );
+    const blocks = getBlocks(kernel);
+    expect(blocks.map((b) => b.type)).toEqual(['text', 'image', 'file', 'text']);
+    expect(blocks[2]).toEqual({
+      name: 'x.pdf',
+      size: 1234,
+      type: 'file',
+      url: 'https://cdn/x.pdf',
+    });
+  });
+
+  it('drops non-uploaded image and adds a loading placeholder', () => {
+    seed(
+      kernel,
+      paragraphRoot([
+        paragraph([textNode('before '), inlineImage({ status: 'loading' }), textNode(' after')]),
+      ]),
+    );
+    const blocks = getBlocks(kernel);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe('text');
+    const text = (blocks[0] as { text: string }).text;
+    expect(text).toContain('before');
+    expect(text).toContain('[image uploading...]');
+    expect(text).toContain('after');
+  });
+
+  it('renders error placeholder with message', () => {
+    seed(kernel, paragraphRoot([blockImage({ status: 'error' })]));
+    const blocks = getBlocks(kernel);
+    expect(blocks).toHaveLength(1);
+    expect((blocks[0] as { text: string }).text).toContain('[image upload failed]');
+  });
+
+  it('drops non-uploaded image silently when placeholder is disabled', () => {
+    seed(
+      kernel,
+      paragraphRoot([
+        paragraph([textNode('a'), inlineImage({ status: 'loading' }), textNode('b')]),
+      ]),
+    );
+    const editor = kernel.getLexicalEditor()!;
+    const service = kernel.requireService(IMarkdownShortCutService)!;
+    const blocks: ContentBlock[] = extractContentBlocks(editor, service, {
+      emitPlaceholderForUnuploaded: false,
+    });
+    // The dropped image leaves two adjacent text segments which then merge.
+    expect(blocks).toEqual([{ text: 'a\n\nb', type: 'text' }]);
+  });
+
+  it('preserves width and height when set', () => {
+    seed(
+      kernel,
+      paragraphRoot([
+        blockImage({
+          altText: 'sized',
+          height: 200,
+          src: 'https://cdn/sized.png',
+          width: 400,
+        }),
+      ]),
+    );
+    expect(getBlocks(kernel)).toEqual([
+      {
+        alt: 'sized',
+        height: 200,
+        type: 'image',
+        url: 'https://cdn/sized.png',
+        width: 400,
+      },
+    ]);
+  });
+
+  it('omits width/height fields when they are 0 (inherit)', () => {
+    seed(kernel, paragraphRoot([blockImage({ altText: 'a', src: 'https://cdn/a.png' })]));
+    const block = getBlocks(kernel)[0] as { width?: number; height?: number };
+    expect(block.width).toBeUndefined();
+    expect(block.height).toBeUndefined();
+  });
+
+  it('preserves multiple consecutive image blocks', () => {
+    seed(
+      kernel,
+      paragraphRoot([
+        blockImage({ altText: 'a', src: 'https://cdn/a.png' }),
+        blockImage({ altText: 'b', src: 'https://cdn/b.png' }),
+      ]),
+    );
+    const blocks = getBlocks(kernel);
+    expect(blocks).toHaveLength(2);
+    expect(blocks.map((b) => (b as { url: string }).url)).toEqual([
+      'https://cdn/a.png',
+      'https://cdn/b.png',
+    ]);
+  });
+});

--- a/src/plugins/content-blocks/utils/extract-media-lists.ts
+++ b/src/plugins/content-blocks/utils/extract-media-lists.ts
@@ -1,0 +1,35 @@
+import type { ContentBlock, FileListItem, ImageListItem, MediaLists } from '../types';
+
+const generateId = (): string => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return `id-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+};
+
+const inferFileType = (name: string): string => {
+  const dotIndex = name.lastIndexOf('.');
+  if (dotIndex < 0 || dotIndex === name.length - 1) return 'unknown';
+  return name.slice(dotIndex + 1).toLowerCase() || 'unknown';
+};
+
+export const extractMediaLists = (blocks: ContentBlock[]): MediaLists => {
+  const imageList: ImageListItem[] = [];
+  const fileList: FileListItem[] = [];
+
+  for (const block of blocks) {
+    if (block.type === 'image') {
+      imageList.push({ alt: block.alt, id: generateId(), url: block.url });
+    } else if (block.type === 'file') {
+      fileList.push({
+        fileType: inferFileType(block.name),
+        id: generateId(),
+        name: block.name,
+        size: typeof block.size === 'number' ? block.size : 0,
+        url: block.url,
+      });
+    }
+  }
+
+  return { fileList, imageList };
+};

--- a/src/plugins/content-blocks/utils/extract.ts
+++ b/src/plugins/content-blocks/utils/extract.ts
@@ -1,0 +1,290 @@
+import type {
+  ElementNode,
+  LexicalEditor,
+  LexicalNode,
+  SerializedElementNode,
+  SerializedLexicalNode,
+} from 'lexical';
+import { $getRoot, $isElementNode } from 'lexical';
+
+import { INodeHelper } from '@/editor-kernel/inode/helper';
+import type { IElementNode } from '@/editor-kernel/inode/i-element-node';
+import { MarkdownWriterContext } from '@/plugins/markdown/data-source/markdown-writer-context';
+import type {
+  IMarkdownShortCutService,
+  MarkdownShortCutService,
+} from '@/plugins/markdown/service/shortcut';
+
+import type {
+  ContentBlock,
+  ExtractContentBlocksOptions,
+  FileContentBlock,
+  ImageContentBlock,
+} from '../types';
+
+const ATOMIC_TYPES = new Set(['image', 'block-image', 'file']);
+const SPLITTABLE_CONTAINER_TYPES = new Set(['paragraph', 'heading', 'quote']);
+
+const PLACEHOLDERS = {
+  fileError: (name: string, msg?: string) =>
+    msg ? `[file upload failed: ${name}: ${msg}]` : `[file upload failed: ${name}]`,
+  fileLoading: (name: string) => `[file uploading: ${name}]`,
+  imageError: (msg?: string | null) =>
+    msg ? `[image upload failed: ${msg}]` : '[image upload failed]',
+  imageLoading: '[image uploading...]',
+};
+
+type ImageLikeNode = LexicalNode & {
+  __altText?: string;
+  __height?: 'inherit' | number;
+  __message?: string | null;
+  __src?: string;
+  __status?: 'uploaded' | 'loading' | 'error';
+  __width?: 'inherit' | number;
+  getAltText?: () => string;
+  getSrc?: () => string;
+};
+
+type FileLikeNode = LexicalNode & {
+  __fileUrl?: string;
+  __message?: string;
+  __name?: string;
+  __size?: number;
+  __status?: 'pending' | 'uploaded' | 'error';
+};
+
+const isAtomicNode = (node: LexicalNode): boolean => ATOMIC_TYPES.has(node.getType());
+
+const isInlineAtomicNode = (node: LexicalNode): boolean => node.getType() === 'image';
+
+const isImageType = (type: string) => type === 'image' || type === 'block-image';
+
+const readImage = (
+  node: ImageLikeNode,
+): {
+  alt: string;
+  height: number;
+  message: string | null;
+  src: string;
+  status: 'uploaded' | 'loading' | 'error';
+  width: number;
+} => {
+  const src = node.getSrc?.() ?? node.__src ?? '';
+  const alt = node.getAltText?.() ?? node.__altText ?? '';
+  const rawWidth = node.__width;
+  const rawHeight = node.__height;
+  const width = typeof rawWidth === 'number' ? rawWidth : 0;
+  const height = typeof rawHeight === 'number' ? rawHeight : 0;
+  return {
+    alt,
+    height,
+    message: node.__message ?? null,
+    src,
+    status: node.__status ?? 'uploaded',
+    width,
+  };
+};
+
+const readFile = (
+  node: FileLikeNode,
+): {
+  message?: string;
+  name: string;
+  size?: number;
+  status: 'pending' | 'uploaded' | 'error';
+  url: string;
+} => ({
+  message: node.__message,
+  name: node.__name ?? 'unknown',
+  size: node.__size,
+  status: node.__status ?? 'pending',
+  url: node.__fileUrl ?? '',
+});
+
+const buildImageBlock = (node: ImageLikeNode): ImageContentBlock | null => {
+  const info = readImage(node);
+  if (info.status !== 'uploaded' || !info.src) return null;
+  const block: ImageContentBlock = {
+    alt: info.alt,
+    type: 'image',
+    url: info.src,
+  };
+  if (info.width > 0) block.width = info.width;
+  if (info.height > 0) block.height = info.height;
+  return block;
+};
+
+const buildFileBlock = (node: FileLikeNode): FileContentBlock | null => {
+  const info = readFile(node);
+  if (info.status !== 'uploaded' || !info.url) return null;
+  const block: FileContentBlock = {
+    name: info.name,
+    type: 'file',
+    url: info.url,
+  };
+  if (typeof info.size === 'number') block.size = info.size;
+  return block;
+};
+
+const placeholderForImage = (node: ImageLikeNode): string => {
+  const info = readImage(node);
+  if (info.status === 'error') return PLACEHOLDERS.imageError(info.message);
+  return PLACEHOLDERS.imageLoading;
+};
+
+const placeholderForFile = (node: FileLikeNode): string => {
+  const info = readFile(node);
+  if (info.status === 'error') return PLACEHOLDERS.fileError(info.name, info.message);
+  return PLACEHOLDERS.fileLoading(info.name);
+};
+
+const hasDirectInlineAtomic = (element: ElementNode): boolean => {
+  for (const child of element.getChildren()) {
+    if (isInlineAtomicNode(child)) return true;
+  }
+  return false;
+};
+
+const exportTree = (node: LexicalNode): SerializedLexicalNode => {
+  const json = node.exportJSON();
+  if ($isElementNode(node)) {
+    const elJson = json as SerializedElementNode;
+    elJson.children = node.getChildren().map((child) => exportTree(child));
+  }
+  return json;
+};
+
+const renderTextBuffer = (
+  editor: LexicalEditor,
+  service: IMarkdownShortCutService,
+  buffer: SerializedLexicalNode[],
+): string => {
+  if (buffer.length === 0) return '';
+  const synRoot = INodeHelper.createRootNode();
+  INodeHelper.appendChild(synRoot, ...(buffer as unknown as IElementNode[]));
+  const synState = editor.parseEditorState({ root: synRoot });
+  const ctx = new MarkdownWriterContext(service as MarkdownShortCutService);
+  return synState.read(() => {
+    const root = synState._nodeMap.get('root') as ElementNode;
+    root.getChildren().forEach((child) => ctx.processChild(ctx, child));
+    return ctx.toString();
+  });
+};
+
+const pushPlaceholderParagraph = (buffer: SerializedLexicalNode[], text: string): void => {
+  const para = INodeHelper.createParagraph();
+  INodeHelper.appendChild(para, INodeHelper.createTextNode(text));
+  buffer.push(para as unknown as SerializedLexicalNode);
+};
+
+const cloneElementShell = (element: ElementNode): IElementNode => {
+  const json = element.exportJSON() as unknown as IElementNode;
+  return { ...json, children: [] };
+};
+
+const mergeAdjacentTextBlocks = (blocks: ContentBlock[]): ContentBlock[] => {
+  const out: ContentBlock[] = [];
+  for (const block of blocks) {
+    const prev = out.at(-1);
+    if (block.type === 'text' && prev?.type === 'text') {
+      prev.text = `${prev.text}\n\n${block.text}`;
+    } else {
+      out.push(block);
+    }
+  }
+  return out;
+};
+
+export const extractContentBlocks = (
+  editor: LexicalEditor,
+  service: IMarkdownShortCutService,
+  options: ExtractContentBlocksOptions = {},
+): ContentBlock[] => {
+  const emitPlaceholder = options.emitPlaceholderForUnuploaded ?? true;
+
+  return editor.getEditorState().read(() => {
+    const root = $getRoot();
+    const blocks: ContentBlock[] = [];
+    const textBuffer: SerializedLexicalNode[] = [];
+
+    const flushText = () => {
+      if (textBuffer.length === 0) return;
+      const md = renderTextBuffer(editor, service, textBuffer).trim();
+      textBuffer.length = 0;
+      if (md) blocks.push({ text: md, type: 'text' });
+    };
+
+    const emitAtomic = (node: LexicalNode) => {
+      if (isImageType(node.getType())) {
+        const block = buildImageBlock(node as ImageLikeNode);
+        if (block) {
+          flushText();
+          blocks.push(block);
+          return;
+        }
+        if (emitPlaceholder) {
+          pushPlaceholderParagraph(textBuffer, placeholderForImage(node as ImageLikeNode));
+        }
+        return;
+      }
+      // file
+      const fNode = node as FileLikeNode;
+      const block = buildFileBlock(fNode);
+      if (block) {
+        flushText();
+        blocks.push(block);
+        return;
+      }
+      if (emitPlaceholder) {
+        pushPlaceholderParagraph(textBuffer, placeholderForFile(fNode));
+      }
+    };
+
+    const visitTopLevel = (node: LexicalNode) => {
+      if (isAtomicNode(node)) {
+        // Root-level atomic — always emit as its own block, even if the node
+        // class declares isInline() (chat editors place inline images inside
+        // paragraphs; at root they are effectively block-level).
+        emitAtomic(node);
+        return;
+      }
+
+      if (!$isElementNode(node)) {
+        textBuffer.push(exportTree(node));
+        return;
+      }
+
+      if (
+        !SPLITTABLE_CONTAINER_TYPES.has(node.getType()) ||
+        !hasDirectInlineAtomic(node as ElementNode)
+      ) {
+        textBuffer.push(exportTree(node));
+        return;
+      }
+
+      // Split the splittable container by its direct inline atomic children.
+      let currentShell = cloneElementShell(node as ElementNode);
+      const commitShell = () => {
+        if (currentShell.children && currentShell.children.length > 0) {
+          textBuffer.push(currentShell as unknown as SerializedLexicalNode);
+        }
+        currentShell = cloneElementShell(node as ElementNode);
+      };
+
+      for (const child of (node as ElementNode).getChildren()) {
+        if (isInlineAtomicNode(child)) {
+          commitShell();
+          emitAtomic(child);
+        } else {
+          currentShell.children!.push(exportTree(child));
+        }
+      }
+      commitShell();
+    };
+
+    root.getChildren().forEach(visitTopLevel);
+    flushText();
+
+    return mergeAdjacentTextBlocks(blocks);
+  });
+};


### PR DESCRIPTION
## Summary

- Adds a new write-only `ContentBlocksPlugin` (parallel to other plugins under `src/plugins/`) that turns the current Lexical state into a typed `ContentBlock[]` — `text` / `image` / `file` parts — matching the message-part format consumed by lobe-chat's context engine.
- Text parts are serialized through the existing `MarkdownPlugin` writer pipeline. Inline images inside paragraphs/headings/quotes are lifted into their own image blocks; root-level atomic nodes are always emitted as standalone blocks.
- Ships `extractMediaLists(blocks)` — a pure helper that derives `{ imageList, fileList }` (with generated ids and extension-inferred `fileType`) from any `ContentBlock[]`.
- Non-uploaded media defaults to a textual placeholder; `emitPlaceholderForUnuploaded: false` drops them silently. Adjacent text blocks are merged with `\n\n`.

### API surface

```ts
const blocks = kernel.getDocument('content-blocks') as ContentBlock[];
const { imageList, fileList } = extractMediaLists(blocks);

// or direct
const blocks = extractContentBlocks(editor, markdownService, { ... });
```

Public exports are wired through `src/index.ts` and documented in `src/plugins/content-blocks/index.md`.

## Test plan

- [x] `vitest run src/plugins/content-blocks` — 16 / 16 passing (11 extract + 5 media-lists)
- [x] `eslint src/plugins/content-blocks src/index.ts` — clean
- [x] `tsc --noEmit` — no errors in the new files (only pre-existing tsconfig deprecation warnings remain)
- [ ] Manual smoke test downstream in lobe-chat after merge