### PR TITLE
feat(utils): add editor-agnostic media list extractor

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,14 @@ export { getHotkeyById } from './utils/hotkey/registerHotkey';
 // URL utilities
 export { isPureUrl, isValidUrl } from './utils/url';
 
+// Editor-state media extraction
+export type {
+  FileListItem,
+  ImageListItem,
+  MediaLists,
+} from './utils/extract-media-from-editor-state';
+export { extractMediaFromEditorState } from './utils/extract-media-from-editor-state';
+
 // Debug utilities
 export {
   browserDebug,

--- a/src/plugins/content-blocks/types.ts
+++ b/src/plugins/content-blocks/types.ts
@@ -1,3 +1,9 @@
+export type {
+  FileListItem,
+  ImageListItem,
+  MediaLists,
+} from '@/utils/extract-media-from-editor-state';
+
 export interface TextContentBlock {
   text: string;
   type: 'text';
@@ -28,25 +34,6 @@ export interface ExtractContentBlocksOptions {
    * @default true
    */
   emitPlaceholderForUnuploaded?: boolean;
-}
-
-export interface ImageListItem {
-  alt: string;
-  id: string;
-  url: string;
-}
-
-export interface FileListItem {
-  fileType: string;
-  id: string;
-  name: string;
-  size: number;
-  url: string;
-}
-
-export interface MediaLists {
-  fileList: FileListItem[];
-  imageList: ImageListItem[];
 }
 
 export const CONTENT_BLOCKS_DATA_TYPE = 'content-blocks';

--- a/src/utils/__tests__/extract-media-from-editor-state.test.ts
+++ b/src/utils/__tests__/extract-media-from-editor-state.test.ts
@@ -1,0 +1,211 @@
+import type { SerializedEditorState } from 'lexical';
+import { describe, expect, it } from 'vitest';
+
+import { extractMediaFromEditorState } from '../extract-media-from-editor-state';
+
+const make = (children: unknown[]): SerializedEditorState =>
+  ({
+    root: {
+      children,
+      direction: null,
+      format: '',
+      indent: 0,
+      type: 'root',
+      version: 1,
+    },
+  }) as unknown as SerializedEditorState;
+
+const text = (t: string) => ({
+  detail: 0,
+  format: 0,
+  mode: 'normal',
+  style: '',
+  text: t,
+  type: 'text',
+  version: 1,
+});
+
+const image = (override: Record<string, unknown> = {}) => ({
+  altText: 'alt',
+  src: 'https://cdn/a.png',
+  status: 'uploaded',
+  type: 'image',
+  version: 1,
+  ...override,
+});
+
+const blockImage = (override: Record<string, unknown> = {}) => ({
+  altText: 'block-alt',
+  src: 'https://cdn/b.png',
+  status: 'uploaded',
+  type: 'block-image',
+  version: 1,
+  ...override,
+});
+
+const file = (override: Record<string, unknown> = {}) => ({
+  fileUrl: 'https://cdn/x.pdf',
+  name: 'x.pdf',
+  size: 1024,
+  status: 'uploaded',
+  type: 'file',
+  version: 1,
+  ...override,
+});
+
+const paragraph = (children: unknown[]) => ({
+  children,
+  direction: null,
+  format: '',
+  indent: 0,
+  textFormat: 0,
+  textStyle: '',
+  type: 'paragraph',
+  version: 1,
+});
+
+const heading = (children: unknown[]) => ({
+  children,
+  direction: null,
+  format: '',
+  indent: 0,
+  tag: 'h1',
+  type: 'heading',
+  version: 1,
+});
+
+const quote = (children: unknown[]) => ({
+  children,
+  direction: null,
+  format: '',
+  indent: 0,
+  type: 'quote',
+  version: 1,
+});
+
+describe('extractMediaFromEditorState', () => {
+  it('returns empty lists for empty state', () => {
+    expect(extractMediaFromEditorState(make([]))).toEqual({ fileList: [], imageList: [] });
+  });
+
+  it('returns empty lists for null/undefined input', () => {
+    expect(extractMediaFromEditorState(null)).toEqual({ fileList: [], imageList: [] });
+    expect(extractMediaFromEditorState(undefined)).toEqual({ fileList: [], imageList: [] });
+  });
+
+  it('extracts top-level image and block-image', () => {
+    const lists = extractMediaFromEditorState(make([blockImage(), file()]));
+    expect(lists.imageList).toHaveLength(1);
+    expect(lists.imageList[0]).toMatchObject({ alt: 'block-alt', url: 'https://cdn/b.png' });
+    expect(lists.fileList).toHaveLength(1);
+    expect(lists.fileList[0]).toMatchObject({
+      fileType: 'pdf',
+      name: 'x.pdf',
+      size: 1024,
+      url: 'https://cdn/x.pdf',
+    });
+  });
+
+  it('extracts images nested inside paragraph/heading/quote (DFS)', () => {
+    const state = make([
+      paragraph([text('before '), image({ src: 'https://cdn/p.png' }), text(' after')]),
+      heading([image({ src: 'https://cdn/h.png' })]),
+      quote([paragraph([image({ src: 'https://cdn/q.png' })])]),
+    ]);
+    const lists = extractMediaFromEditorState(state);
+    const urls = lists.imageList.map((i) => i.url);
+    expect(urls).toEqual(['https://cdn/p.png', 'https://cdn/h.png', 'https://cdn/q.png']);
+  });
+
+  it('skips non-uploaded images and files', () => {
+    const lists = extractMediaFromEditorState(
+      make([
+        image({ status: 'loading' }),
+        image({ status: 'error' }),
+        blockImage({ status: undefined }),
+        file({ status: 'pending' }),
+        file({ status: 'error' }),
+      ]),
+    );
+    expect(lists.imageList).toEqual([]);
+    expect(lists.fileList).toEqual([]);
+  });
+
+  it('skips uploaded entries with empty url', () => {
+    const lists = extractMediaFromEditorState(make([image({ src: '' }), file({ fileUrl: '' })]));
+    expect(lists.imageList).toEqual([]);
+    expect(lists.fileList).toEqual([]);
+  });
+
+  it('does not descend into image caption editor state', () => {
+    const captionedImage = image({
+      caption: {
+        editorState: {
+          root: {
+            children: [paragraph([image({ src: 'https://cdn/inner.png' })])],
+            type: 'root',
+          },
+        },
+      },
+      src: 'https://cdn/outer.png',
+    });
+    const lists = extractMediaFromEditorState(make([captionedImage]));
+    expect(lists.imageList).toHaveLength(1);
+    expect(lists.imageList[0].url).toBe('https://cdn/outer.png');
+  });
+
+  it('preserves DFS pre-order across nested containers', () => {
+    const state = make([
+      paragraph([image({ src: '1' }), image({ src: '2' })]),
+      paragraph([image({ src: '3' })]),
+      blockImage({ src: '4' }),
+    ]);
+    expect(extractMediaFromEditorState(state).imageList.map((i) => i.url)).toEqual([
+      '1',
+      '2',
+      '3',
+      '4',
+    ]);
+  });
+
+  it('infers fileType from extension; falls back to unknown', () => {
+    const lists = extractMediaFromEditorState(
+      make([
+        file({ fileUrl: 'a', name: 'report.PDF' }),
+        file({ fileUrl: 'b', name: 'noext' }),
+        file({ fileUrl: 'c', name: 'archive.tar.gz' }),
+      ]),
+    );
+    expect(lists.fileList.map((f) => f.fileType)).toEqual(['pdf', 'unknown', 'gz']);
+  });
+
+  it('defaults missing size to 0 and missing name to "unknown"', () => {
+    const lists = extractMediaFromEditorState(
+      make([file({ fileUrl: 'u', name: undefined, size: undefined })]),
+    );
+    expect(lists.fileList[0]).toMatchObject({
+      fileType: 'unknown',
+      name: 'unknown',
+      size: 0,
+      url: 'u',
+    });
+  });
+
+  it('generates a unique id per entry', () => {
+    const lists = extractMediaFromEditorState(
+      make([
+        image({ src: 'a' }),
+        image({ src: 'b' }),
+        file({ fileUrl: 'fa', name: 'a.txt' }),
+        file({ fileUrl: 'fb', name: 'b.txt' }),
+      ]),
+    );
+    const ids = [
+      lists.imageList[0].id,
+      lists.imageList[1].id,
+      lists.fileList[0].id,
+      lists.fileList[1].id,
+    ];
+    expect(new Set(ids).size).toBe(4);
+  });
+});

--- a/src/utils/extract-media-from-editor-state.ts
+++ b/src/utils/extract-media-from-editor-state.ts
@@ -1,0 +1,90 @@
+import type { SerializedEditorState, SerializedLexicalNode } from 'lexical';
+
+export interface ImageListItem {
+  alt: string;
+  id: string;
+  url: string;
+}
+
+export interface FileListItem {
+  fileType: string;
+  id: string;
+  name: string;
+  size: number;
+  url: string;
+}
+
+export interface MediaLists {
+  fileList: FileListItem[];
+  imageList: ImageListItem[];
+}
+
+const IMAGE_TYPES = new Set(['image', 'block-image']);
+const FILE_TYPE = 'file';
+
+const generateId = (): string => {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return `id-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+};
+
+const inferFileType = (name: string): string => {
+  const dotIndex = name.lastIndexOf('.');
+  if (dotIndex < 0 || dotIndex === name.length - 1) return 'unknown';
+  return name.slice(dotIndex + 1).toLowerCase() || 'unknown';
+};
+
+type AnyNode = SerializedLexicalNode & {
+  altText?: unknown;
+  children?: unknown;
+  fileUrl?: unknown;
+  name?: unknown;
+  size?: unknown;
+  src?: unknown;
+  status?: unknown;
+};
+
+export const extractMediaFromEditorState = (
+  state: SerializedEditorState | null | undefined,
+): MediaLists => {
+  const imageList: ImageListItem[] = [];
+  const fileList: FileListItem[] = [];
+
+  const visit = (node: AnyNode): void => {
+    const type = node.type;
+    if (IMAGE_TYPES.has(type)) {
+      if (node.status === 'uploaded' && typeof node.src === 'string' && node.src) {
+        imageList.push({
+          alt: typeof node.altText === 'string' ? node.altText : '',
+          id: generateId(),
+          url: node.src,
+        });
+      }
+      return;
+    }
+    if (type === FILE_TYPE) {
+      if (node.status === 'uploaded' && typeof node.fileUrl === 'string' && node.fileUrl) {
+        const name = typeof node.name === 'string' ? node.name : 'unknown';
+        fileList.push({
+          fileType: inferFileType(name),
+          id: generateId(),
+          name,
+          size: typeof node.size === 'number' ? node.size : 0,
+          url: node.fileUrl,
+        });
+      }
+      return;
+    }
+    if (Array.isArray(node.children)) {
+      for (const child of node.children as AnyNode[]) visit(child);
+    }
+  };
+
+  const root = state?.root as AnyNode | undefined;
+  if (root && Array.isArray(root.children)) {
+    for (const child of root.children as AnyNode[]) visit(child);
+  }
+
+  return { fileList, imageList };
+};


### PR DESCRIPTION
## Summary

- Adds `extractMediaFromEditorState(state)` — a pure, editor-agnostic util that walks any `SerializedEditorState` via DFS and returns `{ imageList, fileList }`. No `LexicalEditor` instance, no markdown service, no `ContentBlock[]` intermediate required.
- Recognizes `image` / `block-image` / `file` nodes; only entries with `status === 'uploaded'` and a non-empty url are included; image `caption.editorState` is intentionally not descended into (to avoid double-counting).
- Promotes `ImageListItem` / `FileListItem` / `MediaLists` to the new utils module as the canonical location; `content-blocks` plugin re-exports them so existing imports keep working.

## Why

The existing `extractContentBlocks` + `extractMediaLists` pipeline requires a live `LexicalEditor`, a markdown service, and an intermediate `ContentBlock[]`. For consumers that only want the image / file inventory of a serialized state (e.g. server-side processors, persisted state inspection, headless previews), that's much more than necessary. This adds a 100-line DFS that takes the JSON and returns the two lists directly.

## Test plan

- [x] Unit tests: empty / null / undefined input
- [x] Top-level `image`, `block-image`, `file` extraction
- [x] DFS into `paragraph` / `heading` / `quote`
- [x] Non-uploaded entries skipped; empty url skipped
- [x] `image.caption.editorState` not descended into
- [x] DFS pre-order preserved
- [x] `fileType` inferred from extension, falls back to `unknown`
- [x] Missing `size` / `name` defaulted to `0` / `unknown`
- [x] Unique id per entry
- [x] Existing `content-blocks` tests (16) still pass

## Public API

```ts
import { extractMediaFromEditorState } from '@lobehub/editor';

const { imageList, fileList } = extractMediaFromEditorState(state);
```