### PR TITLE
:sparkles: feat(block): configurable anchor padding & base-ui dropdown

### DIFF
--- a/src/plugins/block/plugin/index.ts
+++ b/src/plugins/block/plugin/index.ts
@@ -23,6 +23,15 @@ import { registerBlockMoveCommand } from '../command';
 import { BlockMenuService, IBlockMenuService } from '../service';
 
 export interface BlockPluginOptions {
+  /**
+   * Inline padding reserved on the editor root so the floating block menu /
+   * drag handle has somewhere to render without overlapping the block content.
+   * Pass `0` (or `'0'`) when the surrounding layout already provides enough
+   * left gutter. Accepts a number (treated as px) or any valid CSS
+   * `padding-inline` value (e.g. `'40px 0'`). When omitted, defaults to 54px
+   * on each side.
+   */
+  anchorPadding?: number | string;
   attributeName?: string;
   className?: string;
 }

--- a/src/plugins/block/react/ReactBlockPlugin.tsx
+++ b/src/plugins/block/react/ReactBlockPlugin.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { $findTableNode, $isTableSelection } from '@lexical/table';
-import { Icon } from '@lobehub/ui';
-import { Button, Dropdown, theme } from 'antd';
+import { DropdownMenu, type DropdownMenuProps, Icon, useAppElement } from '@lobehub/ui';
+import { Button, theme } from 'antd';
 import { cx } from 'antd-style';
 import { $getNodeByKey, $getSelection, $isRangeSelection } from 'lexical';
 import { GripVerticalIcon, PlusIcon } from 'lucide-react';
@@ -40,7 +40,7 @@ import {
   getTableBlockRect,
   isTableBlockElement,
 } from './drag/drag-utils';
-import { styles } from './style';
+import { ANCHOR_PADDING_CSS_VAR, styles } from './style';
 
 export interface ReactBlockPluginProps extends Omit<BlockPluginOptions, 'className'> {
   className?: string;
@@ -72,16 +72,22 @@ const getTableMenuAnchorRect = (element: HTMLElement) => {
 const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
   const { token } = theme.useToken();
   const [editor] = useLexicalComposerContext();
+  const appElement = useAppElement();
   const {
     rootClassName,
     className,
     attributeName,
+    anchorPadding,
     locale,
     onHoverBlockChange,
     onDragTargetChange,
     onDragTargetResolve,
   } = props;
   const mergedRootClassName = cx(styles.root, rootClassName?.trim() || className?.trim());
+  const anchorPaddingValue = useMemo(() => {
+    if (anchorPadding === undefined) return null;
+    return typeof anchorPadding === 'number' ? `${anchorPadding}px` : anchorPadding;
+  }, [anchorPadding]);
   const menuRef = useRef<HTMLDivElement>(null);
   const dragLayerRef = useRef<HTMLDivElement>(null);
   const contextRef = useRef<RuntimeContextRef>(createRuntimeContext());
@@ -110,10 +116,27 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
     }
 
     editor.registerPlugin(BlockPlugin, {
+      anchorPadding,
       attributeName,
       className: mergedRootClassName,
     });
-  }, [attributeName, editor, locale, mergedRootClassName]);
+  }, [anchorPadding, attributeName, editor, locale, mergedRootClassName]);
+
+  useLexicalEditor(
+    (lexicalEditor) =>
+      lexicalEditor.registerRootListener((rootElement, prevRootElement) => {
+        if (prevRootElement) {
+          prevRootElement.style.removeProperty(ANCHOR_PADDING_CSS_VAR);
+        }
+        if (!rootElement) return;
+        if (anchorPaddingValue === null) {
+          rootElement.style.removeProperty(ANCHOR_PADDING_CSS_VAR);
+        } else {
+          rootElement.style.setProperty(ANCHOR_PADDING_CSS_VAR, anchorPaddingValue);
+        }
+      }),
+    [anchorPaddingValue],
+  );
 
   useLexicalEditor(() => {
     const service = editor.requireService(IBlockMenuService) as BlockMenuService | null;
@@ -625,8 +648,44 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
     };
   }, [blockMenuSuppressed, editor, isDragging]);
 
+  const menuContext = useMemo<IBlockMenuRenderContext | null>(() => {
+    if (operationMenuOpen && operationMenuContext) {
+      return operationMenuContext;
+    }
+
+    const lockedContext = blockMenuService?.getMenuLockedContext();
+    if (lockedContext) {
+      const root = editor.getRootElement();
+      const fresh = root?.querySelector<HTMLElement>(
+        `[data-block-id="${CSS.escape(lockedContext.blockId)}"]`,
+      );
+      if (fresh && root?.contains(fresh)) {
+        return {
+          blockElement: fresh,
+          blockId: lockedContext.blockId,
+          editor,
+        };
+      }
+    }
+
+    if (!hoveredBlock) return null;
+
+    return {
+      blockElement: hoveredBlock.blockElement,
+      blockId: hoveredBlock.blockId,
+      editor,
+    };
+  }, [
+    editor,
+    hoveredBlock,
+    operationMenuOpen,
+    operationMenuContext,
+    blockMenuService,
+    menuVersion,
+  ]);
+
   useLayoutEffect(() => {
-    if (!hoveredBlock) {
+    if (!menuContext) {
       if (operationMenuOpen) {
         return;
       }
@@ -636,7 +695,7 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
     }
 
     const updateMenuPosition = () => {
-      const blockRect = getBlockMeasureRect(hoveredBlock.blockElement);
+      const blockRect = getBlockMeasureRect(menuContext.blockElement);
       if (!blockRect) {
         setMenuPosition({});
         return;
@@ -644,12 +703,12 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
 
       const menuWidth = menuRef.current?.offsetWidth || 32;
       const gap = 8;
-      const listItemOffset = hoveredBlock.blockElement.tagName === 'LI' ? 16 : 0;
-      const isTableBlock = isTableBlockElement(hoveredBlock.blockElement);
-      const isFocusedTableBlock = focusedTableBlockId === hoveredBlock.blockId && isTableBlock;
+      const listItemOffset = menuContext.blockElement.tagName === 'LI' ? 16 : 0;
+      const isTableBlock = isTableBlockElement(menuContext.blockElement);
+      const isFocusedTableBlock = focusedTableBlockId === menuContext.blockId && isTableBlock;
       const tableMenuOffset = isFocusedTableBlock ? TABLE_FOCUSED_MENU_OFFSET : 0;
       const tableAnchorRect = isTableBlock
-        ? getTableMenuAnchorRect(hoveredBlock.blockElement)
+        ? getTableMenuAnchorRect(menuContext.blockElement)
         : null;
       const root = editor.getRootElement();
       const rootRect = root?.getBoundingClientRect();
@@ -683,17 +742,7 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
       window.removeEventListener('resize', updateMenuPosition);
       document.removeEventListener('scroll', updateMenuPosition, true);
     };
-  }, [editor, focusedTableBlockId, hoveredBlock, layoutVersion, operationMenuOpen]);
-
-  const menuContext = useMemo<IBlockMenuRenderContext | null>(() => {
-    if (!hoveredBlock) return null;
-
-    return {
-      blockElement: hoveredBlock.blockElement,
-      blockId: hoveredBlock.blockId,
-      editor,
-    };
-  }, [editor, hoveredBlock]);
+  }, [editor, focusedTableBlockId, menuContext, layoutVersion, operationMenuOpen]);
 
   const operationMenus = useMemo(() => {
     if (!operationMenuContext || !blockMenuService) return [];
@@ -780,23 +829,6 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
     setDragIndicator(null);
   };
 
-  const toggleOperationMenu = (context: IBlockMenuRenderContext | null) => {
-    if (!context) {
-      setOperationMenuOpen(false);
-      setOperationMenuContext(null);
-      return;
-    }
-
-    setOperationMenuOpen((open) => {
-      const shouldOpen = !(
-        open && contextRef.current.operationMenuAnchorBlockId === context.blockId
-      );
-      contextRef.current.operationMenuAnchorBlockId = shouldOpen ? context.blockId : null;
-      setOperationMenuContext(shouldOpen ? context : null);
-      return shouldOpen;
-    });
-  };
-
   const handleDragHandlePointerDown = (event: ReactPointerEvent<HTMLElement>) => {
     if (!menuContext) return;
 
@@ -815,20 +847,29 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
       setDragIndicator,
       setOperationMenuContext,
       setOperationMenuOpen,
-      toggleOperationMenu,
     });
   };
 
-  const handleDragHandleClick = () => {
+  const handleOperationMenuOpenChange = (open: boolean) => {
     if (contextRef.current.ignoreNextHandleClick) {
       contextRef.current.ignoreNextHandleClick = false;
       return;
     }
 
-    toggleOperationMenu(menuContext);
+    if (!menuContext) return;
+
+    if (open) {
+      setOperationMenuOpen(true);
+      setOperationMenuContext(menuContext);
+      contextRef.current.operationMenuAnchorBlockId = menuContext.blockId;
+    } else {
+      setOperationMenuOpen(false);
+      setOperationMenuContext(null);
+      contextRef.current.operationMenuAnchorBlockId = null;
+    }
   };
 
-  const dropdownItems = useMemo(
+  const dropdownItems = useMemo<DropdownMenuProps['items']>(
     () =>
       operationMenus.map((item) => ({
         key: item.key,
@@ -864,36 +905,25 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
               />
             );
           })}
-          <Dropdown
-            align={{
-              points: ['tr', 'tl'],
-            }}
-            classNames={{
-              root: OPERATION_MENU_OVERLAY_CLASS,
-            }}
-            menu={{ items: dropdownItems }}
-            onOpenChange={(open) => {
-              if (!open) {
-                setOperationMenuOpen(false);
-                setOperationMenuContext(null);
-                contextRef.current.operationMenuAnchorBlockId = null;
-              }
-            }}
+          <DropdownMenu
+            items={dropdownItems}
+            onOpenChange={handleOperationMenuOpenChange}
             open={operationMenuOpen && operationMenuContext?.blockId === menuContext.blockId}
-            trigger={[]}
+            placement={'leftTop'}
+            popupProps={{ className: OPERATION_MENU_OVERLAY_CLASS }}
+            positionerProps={{ style: { zIndex: 1000 } }}
           >
             <Button
               aria-label={'Block actions and drag'}
               className={styles.dragHandle}
               data-block-drag-handle={'true'}
               icon={<Icon icon={GripVerticalIcon} size={14} />}
-              onClick={handleDragHandleClick}
               onPointerDown={handleDragHandlePointerDown}
               size={'small'}
               title={'Block actions and drag'}
               type={'text'}
             />
-          </Dropdown>
+          </DropdownMenu>
         </div>
       </div>
     ) : null;
@@ -925,7 +955,7 @@ const ReactBlockPlugin: FC<ReactBlockPluginProps> = (props) => {
               />
             )}
           </>,
-          document.body,
+          appElement ?? document.body,
         )}
     </>
   );

--- a/src/plugins/block/react/drag/drag-session.ts
+++ b/src/plugins/block/react/drag/drag-session.ts
@@ -36,7 +36,6 @@ interface StartBlockDragSessionParams {
   setDragIndicator: (value: DragIndicator | null) => void;
   setOperationMenuContext: (value: IBlockMenuRenderContext | null) => void;
   setOperationMenuOpen: (value: boolean) => void;
-  toggleOperationMenu: (context: IBlockMenuRenderContext | null) => void;
 }
 
 const DRAG_GHOST_OFFSET_X = 14;
@@ -136,9 +135,7 @@ export const startBlockDragSession = ({
   setDragIndicator,
   setOperationMenuContext,
   setOperationMenuOpen,
-  toggleOperationMenu,
 }: StartBlockDragSessionParams) => {
-  setOperationMenuOpen(false);
   let dragGhost: HTMLDivElement | null = null;
   let restoreSourceOpacity: (() => void) | null = null;
 
@@ -264,10 +261,6 @@ export const startBlockDragSession = ({
 
   const onPointerUp = () => {
     if (!contextRef.current.dragStarted && !contextRef.current.dragMoved) {
-      toggleOperationMenu(menuContext);
-      // Pointerup may be followed by click; consume it to avoid immediate double toggle.
-      contextRef.current.ignoreNextHandleClick = true;
-
       contextRef.current.draggingSource = null;
       contextRef.current.dragPointerY = null;
       contextRef.current.dragBlocks = [];

--- a/src/plugins/block/react/index.ts
+++ b/src/plugins/block/react/index.ts
@@ -1,2 +1,3 @@
 export type { BlockDragTarget } from './core/types';
 export { default as ReactBlockPlugin, type ReactBlockPluginProps } from './ReactBlockPlugin';
+export { ANCHOR_PADDING_CSS_VAR, DEFAULT_BLOCK_ANCHOR_PADDING } from './style';

--- a/src/plugins/block/react/style.ts
+++ b/src/plugins/block/react/style.ts
@@ -1,5 +1,15 @@
 import { createStaticStyles } from 'antd-style';
 
+export const ANCHOR_PADDING_CSS_VAR = '--lobe-block-anchor-padding';
+
+/**
+ * Default inline padding (px) reserved on the editor root so the floating
+ * block menu / drag handle has room to render. Exported for consumers that
+ * need to align surrounding chrome (e.g. a title section above the editor)
+ * with the editor's content edge.
+ */
+export const DEFAULT_BLOCK_ANCHOR_PADDING = 54;
+
 export const styles = createStaticStyles(({ css, cssVar }) => ({
   dragHandle: css`
     cursor: grab !important;
@@ -59,6 +69,6 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   root: css`
-    padding-inline: 54px 54px;
+    padding-inline: var(${ANCHOR_PADDING_CSS_VAR}, ${DEFAULT_BLOCK_ANCHOR_PADDING}px);
   `,
 }));

--- a/src/plugins/block/service/i-block-menu-service.ts
+++ b/src/plugins/block/service/i-block-menu-service.ts
@@ -36,12 +36,25 @@ export interface IBlockSelectHandler {
 
 export interface IBlockMenuService {
   getActionButtons(context: IBlockMenuRenderContext): IBlockActionButton[];
+  /**
+   * Returns the currently pinned menu context, or null when no lock is active.
+   * While locked, the block menu UI freezes at the pinned block and hover
+   * detection no longer reassigns the anchor.
+   */
+  getMenuLockedContext(): IBlockMenuRenderContext | null;
   getMenus(context: IBlockMenuRenderContext): IBlockMenuItem[];
   isMenuSuppressed(): boolean;
   registerActionButton(item: IBlockActionButton): () => void;
   registerMenu(item: IBlockMenuItem): () => void;
   registerSelectHandler(item: IBlockSelectHandler): () => void;
   selectNode(node: LexicalNode): boolean;
+  /**
+   * Pin the block menu UI to the provided context (typically while a consumer
+   * popup spawned by an action button is open). Pass `null` for `context` to
+   * release the lock owned by `key`. Multiple keys may hold locks
+   * simultaneously; the most recently set lock wins.
+   */
+  setMenuLockedContext(key: string, context: IBlockMenuRenderContext | null): void;
   setMenuSuppressed(key: string, suppressed: boolean): void;
   subscribe(listener: () => void): () => void;
 }
@@ -54,6 +67,7 @@ export class BlockMenuService implements IBlockMenuService {
   private actionButtons: Map<string, IBlockActionButton> = new Map();
   private items: Map<string, IBlockMenuItem> = new Map();
   private listeners: Set<() => void> = new Set();
+  private lockedContexts: Map<string, IBlockMenuRenderContext> = new Map();
   private selectHandlers: Map<string, IBlockSelectHandler> = new Map();
   private suppressors: Set<string> = new Set();
 
@@ -61,6 +75,15 @@ export class BlockMenuService implements IBlockMenuService {
     return Array.from(this.actionButtons.values())
       .filter((item) => (item.when ? item.when(context) : true))
       .sort((a, b) => (a.order || 0) - (b.order || 0));
+  }
+
+  getMenuLockedContext(): IBlockMenuRenderContext | null {
+    if (this.lockedContexts.size === 0) return null;
+    let last: IBlockMenuRenderContext | null = null;
+    for (const ctx of this.lockedContexts.values()) {
+      last = ctx;
+    }
+    return last;
   }
 
   getMenus(context: IBlockMenuRenderContext): IBlockMenuItem[] {
@@ -115,6 +138,22 @@ export class BlockMenuService implements IBlockMenuService {
     }
 
     return false;
+  }
+
+  setMenuLockedContext(key: string, context: IBlockMenuRenderContext | null): void {
+    const existing = this.lockedContexts.get(key);
+
+    if (context === null) {
+      if (!this.lockedContexts.delete(key)) return;
+      this.notify();
+      return;
+    }
+
+    if (existing === context) return;
+
+    this.lockedContexts.delete(key);
+    this.lockedContexts.set(key, context);
+    this.notify();
   }
 
   setMenuSuppressed(key: string, suppressed: boolean): void {

--- a/src/plugins/slash/plugin/index.ts
+++ b/src/plugins/slash/plugin/index.ts
@@ -21,6 +21,8 @@ import {
 } from '../service/i-slash-service';
 import { getQueryTextForSearch, tryToPositionRange } from '../utils/utils';
 
+const SLASH_ADD_LOCK_KEY = '__slash_add_below';
+
 export interface ITriggerContext {
   getRect: () => DOMRect;
   items:
@@ -54,6 +56,7 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
   static readonly pluginName = 'SlashPlugin';
 
   private service: SlashService | null = null;
+  private blockMenuService: IBlockMenuService | null = null;
   private currentSlashTrigger: string | null = null;
   private currentSlashTriggerIndex = -1;
   private manualOpen = false;
@@ -85,15 +88,19 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
     this.manualOpen = false;
     // After an explicit close, suppress reopening until next typing input
     this.suppressOpen = true;
+    // Release the block-menu anchor lock acquired when the add-block button
+    // spawned this slash menu (no-op when not held).
+    this.blockMenuService?.setMenuLockedContext(SLASH_ADD_LOCK_KEY, null);
   }
 
   onInit(editor: LexicalEditor): void {
     const blockMenuService = this.kernel.requireService(IBlockMenuService);
+    this.blockMenuService = blockMenuService;
 
     if (blockMenuService) {
       const unregisterAddBlockButton = blockMenuService.registerActionButton({
         icon: 'plus',
-        key: '__slash_add_below',
+        key: SLASH_ADD_LOCK_KEY,
         onClick: (context) => {
           const lexicalEditor = context.editor.getLexicalEditor();
           if (!lexicalEditor) return;
@@ -146,6 +153,10 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
             match: null,
             trigger: slashOptions.trigger,
           });
+          // Pin the block-menu anchor to the clicked block while the slash
+          // menu is open, mirroring the drag-handle dropdown's lock so the
+          // action bar does not chase the cursor.
+          blockMenuService.setMenuLockedContext(SLASH_ADD_LOCK_KEY, context);
         },
         order: -100,
         title: 'Add block below',
@@ -277,6 +288,8 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
   }
 
   destroy(): void {
+    this.blockMenuService?.setMenuLockedContext(SLASH_ADD_LOCK_KEY, null);
+    this.blockMenuService = null;
     super.destroy();
   }
 };

--- a/src/plugins/slash/react/components/DefaultSlashMenu.tsx
+++ b/src/plugins/slash/react/components/DefaultSlashMenu.tsx
@@ -126,12 +126,11 @@ const DefaultSlashMenu: FC<DefaultSlashMenuProps> = ({
       const isDisabled = Boolean(item.disabled);
 
       return (
-        <button
+        <div
           aria-disabled={isDisabled || undefined}
           className={menuSharedStyles.item}
           data-disabled={isDisabled ? '' : undefined}
           data-highlighted={isHighlighted ? '' : undefined}
-          disabled={isDisabled}
           key={String(item.key)}
           onClick={() => {
             if (isDisabled) return;
@@ -139,7 +138,7 @@ const DefaultSlashMenu: FC<DefaultSlashMenuProps> = ({
           }}
           // Prevent the editor from losing focus when the popup is clicked.
           onMouseDown={(event) => event.preventDefault()}
-          type={'button'}
+          role={'menuitem'}
         >
           {item.icon ? (
             <span className={menuSharedStyles.icon}>
@@ -148,7 +147,7 @@ const DefaultSlashMenu: FC<DefaultSlashMenuProps> = ({
           ) : null}
           <span className={menuSharedStyles.label}>{item.label}</span>
           {item.extra ? <span className={menuSharedStyles.extra}>{item.extra}</span> : null}
-        </button>
+        </div>
       );
     })
   );

--- a/src/plugins/slash/react/components/DefaultSlashMenu.tsx
+++ b/src/plugins/slash/react/components/DefaultSlashMenu.tsx
@@ -61,7 +61,7 @@ const DefaultSlashMenu: FC<DefaultSlashMenuProps> = ({
   const getRectRef = useRef(position.getRect);
   getRectRef.current = position.getRect;
 
-  const { refs, floatingStyles, update } = useFloating({
+  const { refs, floatingStyles, isPositioned, update } = useFloating({
     middleware,
     open,
     placement: resolvedPlacement,
@@ -157,7 +157,10 @@ const DefaultSlashMenu: FC<DefaultSlashMenuProps> = ({
       className={styles.root}
       data-resloved-placement={resolvedPlacement}
       ref={refs.setFloating}
-      style={floatingStyles}
+      // Hide until floating-ui has measured to avoid a one-frame flash at 0,0
+      // on first open (the layout effect attaches the reference *after* the
+      // initial render, so the first floatingStyles fall back to top-left).
+      style={{ ...floatingStyles, visibility: isPositioned ? 'visible' : 'hidden' }}
     >
       <div className={styles.popup}>{renderedItems}</div>
     </div>

--- a/src/plugins/slash/react/components/DefaultSlashMenu.tsx
+++ b/src/plugins/slash/react/components/DefaultSlashMenu.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { type Placement, flip, offset, shift, useFloating } from '@floating-ui/react';
-import { Menu, type MenuProps } from '@lobehub/ui';
+import { Icon, menuSharedStyles } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
-import { type FC, useCallback, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
+import { type FC, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
 import { ISlashMenuOption } from '../../service/i-slash-service';
@@ -12,16 +12,12 @@ import type { SlashMenuProps } from '../type';
 const LOBE_THEME_APP_ID = 'lobe-ui-theme-app';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
-  menu: css`
-    z-index: 9999;
-    width: max-content;
-  `,
   popup: css`
     scrollbar-width: none;
 
     overflow-y: auto;
 
-    min-width: 120px;
+    min-width: 200px;
     max-height: min(50vh, 400px);
     padding: 4px;
     border-radius: ${cssVar.borderRadius};
@@ -32,68 +28,15 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
       0 0 15px 0 #00000008,
       0 2px 30px 0 #00000014,
       0 0 0 1px ${cssVar.colorBorder} inset;
-
-    .ant-menu {
-      min-width: 200px;
-      padding: 0 !important;
-      border-inline-end: none !important;
-
-      color: ${cssVar.colorText} !important;
-
-      background: transparent !important;
-      background-color: transparent !important;
-    }
-
-    .ant-menu-item {
-      overflow: hidden;
-      display: flex !important;
-      align-items: center;
-
-      width: 100% !important;
-      min-height: 36px;
-      margin: 0 !important;
-      padding-block: 8px !important;
-      padding-inline: 12px !important;
-      border-radius: ${cssVar.borderRadiusSM} !important;
-
-      font-size: 14px;
-      line-height: 20px;
-      color: ${cssVar.colorText} !important;
-
-      background: transparent !important;
-
-      transition: all 150ms ${cssVar.motionEaseOut};
-
-      &:hover,
-      &.ant-menu-item-active {
-        background: ${cssVar.colorFillTertiary} !important;
-      }
-
-      &:active {
-        background: ${cssVar.colorFillSecondary} !important;
-      }
-    }
-
-    .ant-menu-item-divider {
-      height: 1px;
-      margin-block: 4px !important;
-      margin-inline: 0 !important;
-      background: ${cssVar.colorBorder} !important;
-    }
-
-    .ant-menu-title-content,
-    .ant-menu-title-content-with-extra {
-      overflow: visible;
-      display: inline-flex;
-      gap: 24px;
-      justify-content: space-between;
-
-      width: 100%;
-
-      text-overflow: unset;
-    }
+  `,
+  root: css`
+    z-index: 1100;
+    width: max-content;
   `,
 }));
+
+const isDividerOption = (option: SlashMenuProps['options'][number]): boolean =>
+  'type' in option && option.type === 'divider';
 
 type DefaultSlashMenuProps = Omit<SlashMenuProps, 'customRender' | 'onActiveKeyChange' | 'editor'>;
 
@@ -164,50 +107,60 @@ const DefaultSlashMenu: FC<DefaultSlashMenuProps> = ({
     };
   }, [open, getPopupContainer, update]);
 
-  const handleMenuClick: MenuProps['onClick'] = useCallback(
-    ({ key }: { key: string }) => {
-      const option = options.find(
-        (item): item is ISlashMenuOption => 'key' in item && item.key === key,
-      );
-      if (option) onSelect(option);
-    },
-    [options, onSelect],
-  );
-
-  const hasVisibleItems = options?.some(
-    (item) => !('type' in item && item.type === 'divider'),
-  );
+  const hasVisibleItems = options?.some((item) => !isDividerOption(item));
   if (!open || !hasVisibleItems) return null;
 
   const portalContainer =
     getPopupContainer?.() || document.getElementById(LOBE_THEME_APP_ID) || document.body;
 
+  const renderedItems = loading ? (
+    <div className={menuSharedStyles.empty}>Loading...</div>
+  ) : (
+    options.map((opt, index) => {
+      if (isDividerOption(opt)) {
+        return <div className={menuSharedStyles.separator} key={`__divider_${index}`} />;
+      }
+
+      const item = opt as ISlashMenuOption;
+      const isHighlighted = item.key === activeKey;
+      const isDisabled = Boolean(item.disabled);
+
+      return (
+        <button
+          aria-disabled={isDisabled || undefined}
+          className={menuSharedStyles.item}
+          data-disabled={isDisabled ? '' : undefined}
+          data-highlighted={isHighlighted ? '' : undefined}
+          disabled={isDisabled}
+          key={String(item.key)}
+          onClick={() => {
+            if (isDisabled) return;
+            onSelect(item);
+          }}
+          // Prevent the editor from losing focus when the popup is clicked.
+          onMouseDown={(event) => event.preventDefault()}
+          type={'button'}
+        >
+          {item.icon ? (
+            <span className={menuSharedStyles.icon}>
+              <Icon icon={item.icon} />
+            </span>
+          ) : null}
+          <span className={menuSharedStyles.label}>{item.label}</span>
+          {item.extra ? <span className={menuSharedStyles.extra}>{item.extra}</span> : null}
+        </button>
+      );
+    })
+  );
+
   const node = (
     <div
-      className={styles.menu}
+      className={styles.root}
       data-resloved-placement={resolvedPlacement}
       ref={refs.setFloating}
       style={floatingStyles}
     >
-      <div className={styles.popup}>
-        <Menu
-          // @ts-ignore - activeKey is a valid antd Menu prop passed via ...rest
-          activeKey={activeKey}
-          items={
-            loading
-              ? [
-                  {
-                    disabled: true,
-                    key: 'loading',
-                    label: 'Loading...',
-                  },
-                ]
-              : options
-          }
-          onClick={handleMenuClick}
-          selectable={false}
-        />
-      </div>
+      <div className={styles.popup}>{renderedItems}</div>
     </div>
   );
 

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -19,3 +19,4 @@ export { useEditor } from './hooks/useEditor';
 export { type EditorState, useEditorState } from './hooks/useEditorState';
 export { default as SendButton, type SendButtonProps } from './SendButton';
 export { default as SlashMenu, type SlashMenuProps } from './SlashMenu';
+export { ANCHOR_PADDING_CSS_VAR, DEFAULT_BLOCK_ANCHOR_PADDING } from '@/plugins/block/react/style';


### PR DESCRIPTION
## Summary

- **Configurable anchor padding** — `BlockPluginOptions.anchorPadding` (`number | string`) lets consumers shrink or remove the inline padding the block plugin reserves on the editor root for the floating menu/drag handle. Implemented via a CSS variable (`--lobe-block-anchor-padding`) wired up per-editor through Lexical's `registerRootListener`. The default (54 px) is also exported as `DEFAULT_BLOCK_ANCHOR_PADDING` so surrounding chrome (e.g. a title section above the editor) can align with the editor's content edge.
- **Base-ui dropdown** — the drag-handle menu now uses `@lobehub/ui`'s `DropdownMenu` (base-ui backed) instead of antd's `Dropdown`. Click handling lives entirely on `Menu.Trigger` via `onOpenChange`; the drag-session no longer double-toggles the menu, which fixes the first-click-immediately-closes regression. Placement `tr/tl` → `leftTop`; popup `className` still carries `OPERATION_MENU_OVERLAY_CLASS` so hover-detection's `closest()` lookups continue to work.
- **Shared stacking context** — the block-menu portal target moved from `document.body` to `useAppElement()` (`#${LOBE_THEME_APP_ID}`), so the action bar and the base-ui popup live in the same stacking context. Without this the base-ui popup (inside the app element's `isolation: isolate` boundary) sat below the action bar regardless of z-index. Positioner z-index raised to 1000.
- **Lock while menu is open** — `menuContext` and the position effect now derive from the locked context whenever the operation menu is open. Hovering away from the trigger no longer drags the action bar to another block (which previously closed the popup the instant the cursor crossed the trigger→popup gap).
- **Lock API for consumers** — `BlockMenuService.setMenuLockedContext(key, context | null)` / `getMenuLockedContext()` let consumers (e.g. an "add block" action that spawns a custom popup) pin the action bar to a specific block until they release the lock. Multiple keys are supported; the most recently set lock wins.

## Test plan

- [ ] Hover a block — `+` and drag handle appear at the expected position
- [ ] Click drag handle — menu opens on the first click and stays open
- [ ] While menu is open, move the mouse across blocks — action bar stays anchored, menu stays open
- [ ] Click outside / press ESC — menu closes and action bar resumes following hover
- [ ] Start a drag from the handle — menu stays closed, no spurious open after drop
- [ ] Pass `anchorPadding={0}` from a consumer — editor content no longer has 54 px gutters; menu still renders if the parent layout provides room
- [ ] In a `ThemeProvider`-wrapped app, popup sits visually above the action bar