### PR TITLE
✨ feat(collaboration): add editor collaboration contract

### DIFF
--- a/examples/collaboration-business-demo/.gitignore
+++ b/examples/collaboration-business-demo/.gitignore
@@ -1,0 +1,2 @@
+dist
+node_modules

--- a/examples/collaboration-business-demo/README.md
+++ b/examples/collaboration-business-demo/README.md
@@ -1,0 +1,46 @@
+# Collaboration Business Demo
+
+This demo validates the intended business integration shape for `@lobehub/editor` collaboration:
+
+| Layer             | Responsibility                                                   |
+| ----------------- | ---------------------------------------------------------------- |
+| Hono server       | Room snapshot, Yjs update relay, awareness relay                 |
+| Vite React app    | Workspace/page routing shell, provider factory, editor embedding |
+| `@lobehub/editor` | Lexical/Yjs binding, cursor rendering, bootstrap/hydrate         |
+
+## Run
+
+```bash
+pnpm install --lockfile=false
+pnpm dev
+```
+
+Open:
+
+```text
+http://localhost:5174
+```
+
+The Hono relay listens on `http://localhost:8797` by default; Vite proxies `/api` to it.
+
+The page renders simulated browser clients for the same workspace page. Each client owns an independent `Y.Doc` and connects to the Hono room relay through the same `Editor` `collaboration` prop shape that a business page would use.
+
+## Covered Scenarios
+
+| Scenario                          | Demo control                                                      |
+| --------------------------------- | ----------------------------------------------------------------- |
+| First editor enters an empty page | Alice bootstraps JSON into an empty Y.Doc room                    |
+| Later editor enters the same page | Bo hydrates from the server room snapshot                         |
+| User leaves and rejoins           | Remove/Rejoin Bo                                                  |
+| Client remounts in the same page  | Re-enter clients                                                  |
+| Temporary network/session detach  | Disconnect/Reconnect inside each pane                             |
+| Workspace page switch             | Page segmented control                                            |
+| Read-only viewer presence         | Show/Hide observer                                                |
+| Complex editor nodes              | Initial content includes list, table, image, and code block nodes |
+| Room reset/backfill retry         | Reset room                                                        |
+
+Permission and authorization checks are intentionally excluded from this local demo.
+
+## Scope
+
+This is intentionally not production infrastructure. It keeps room state in memory, uses Server-Sent Events for the local relay, and resets on server restart. Its purpose is to validate the integration boundary before wiring a persistent provider in the production application.

--- a/examples/collaboration-business-demo/index.html
+++ b/examples/collaboration-business-demo/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lobe Editor Collaboration Business Demo</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/collaboration-business-demo/package.json
+++ b/examples/collaboration-business-demo/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@lobehub/editor-collaboration-business-demo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json --noEmit && vite build",
+    "dev": "tsx scripts/dev.ts",
+    "dev:client": "vite --host 0.0.0.0 --port 5174",
+    "dev:server": "tsx watch server/index.ts",
+    "type-check": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.14.4",
+    "@vitejs/plugin-react": "^5.1.1",
+    "hono": "^4.10.7",
+    "vite": "^7.2.7"
+  },
+  "devDependencies": {
+    "@types/node": "^25.0.2",
+    "tsx": "^4.21.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/examples/collaboration-business-demo/scripts/dev.ts
+++ b/examples/collaboration-business-demo/scripts/dev.ts
@@ -1,0 +1,37 @@
+import { spawn } from 'node:child_process';
+
+const commands = [
+  ['server', ['exec', 'tsx', 'watch', 'server/index.ts']],
+  ['client', ['exec', 'vite', '--host', '0.0.0.0', '--port', '5174']],
+] as const;
+
+const children = commands.map(([name, args]) => {
+  const child = spawn('pnpm', args, {
+    stdio: 'inherit',
+  });
+
+  child.on('exit', (code) => {
+    if (code && code !== 0) {
+      console.error(`[${name}] exited with code ${code}`);
+      process.exitCode = code;
+    }
+  });
+
+  return child;
+});
+
+const stop = () => {
+  for (const child of children) {
+    child.kill('SIGINT');
+  }
+};
+
+process.on('SIGINT', () => {
+  stop();
+  process.exit(0);
+});
+
+process.on('SIGTERM', () => {
+  stop();
+  process.exit(0);
+});

--- a/examples/collaboration-business-demo/server/codec.ts
+++ b/examples/collaboration-business-demo/server/codec.ts
@@ -1,0 +1,3 @@
+export const bytesToBase64 = (bytes: Uint8Array) => Buffer.from(bytes).toString('base64');
+
+export const base64ToBytes = (value: string) => new Uint8Array(Buffer.from(value, 'base64'));

--- a/examples/collaboration-business-demo/server/index.ts
+++ b/examples/collaboration-business-demo/server/index.ts
@@ -1,0 +1,112 @@
+import { serve } from '@hono/node-server';
+import { Hono } from 'hono';
+import { cors } from 'hono/cors';
+
+import {
+  type AwarenessPayload,
+  type DocumentUpdatePayload,
+  addClient,
+  applyAwarenessUpdate,
+  applyDocumentUpdate,
+  getSnapshot,
+  removeClient,
+  resetRoom,
+} from './rooms';
+
+const app = new Hono();
+
+app.use('/api/*', cors());
+
+app.get('/api/health', (context) =>
+  context.json({
+    ok: true,
+    service: 'collaboration-business-demo',
+  }),
+);
+
+app.get('/api/workspaces/:workspaceId/pages/:pageId', (context) => {
+  const workspaceId = context.req.param('workspaceId');
+  const pageId = context.req.param('pageId');
+  const titles: Record<string, string> = {
+    'launch-notes': 'Q3 Launch Notes',
+    'retrospective': 'Release Retrospective',
+    'roadmap': 'Workspace Roadmap',
+  };
+
+  return context.json({
+    page: {
+      id: pageId,
+      title: titles[pageId] ?? pageId,
+      workspaceId,
+    },
+    roomId: `${workspaceId}:${pageId}`,
+  });
+});
+
+app.get('/api/rooms/:roomId/snapshot', (context) => {
+  return context.json(getSnapshot(context.req.param('roomId')));
+});
+
+app.post('/api/rooms/:roomId/update', async (context) => {
+  const payload = await context.req.json<DocumentUpdatePayload>();
+  applyDocumentUpdate(context.req.param('roomId'), payload);
+
+  return context.json({ ok: true });
+});
+
+app.post('/api/rooms/:roomId/awareness', async (context) => {
+  const payload = await context.req.json<AwarenessPayload>();
+  applyAwarenessUpdate(context.req.param('roomId'), payload);
+
+  return context.json({ ok: true });
+});
+
+app.delete('/api/rooms/:roomId', (context) => {
+  resetRoom(context.req.param('roomId'));
+
+  return context.json({ ok: true });
+});
+
+app.get('/api/rooms/:roomId/events', (context) => {
+  const roomId = context.req.param('roomId');
+  const clientID = Number(context.req.query('clientID'));
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream<Uint8Array>({
+    cancel: () => {
+      removeClient(roomId, clientID);
+    },
+    start: (controller) => {
+      const send = (event: string, data: unknown) => {
+        controller.enqueue(encoder.encode(`event: ${event}\n`));
+        controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
+      };
+
+      addClient(roomId, {
+        clientID,
+        send,
+      });
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Cache-Control': 'no-cache, no-transform',
+      'Connection': 'keep-alive',
+      'Content-Type': 'text/event-stream',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+});
+
+const port = Number(process.env.PORT ?? 8797);
+
+serve(
+  {
+    fetch: app.fetch,
+    port,
+  },
+  (info) => {
+    console.info(`Hono collaboration relay listening on http://localhost:${info.port}`);
+  },
+);

--- a/examples/collaboration-business-demo/server/rooms.ts
+++ b/examples/collaboration-business-demo/server/rooms.ts
@@ -1,0 +1,151 @@
+import { Doc, applyUpdate, encodeStateAsUpdate } from 'yjs';
+
+import { base64ToBytes, bytesToBase64 } from './codec';
+
+export interface SerializedRelativePosition {
+  assoc?: number;
+  item?: {
+    client: number;
+    clock: number;
+  };
+  tname?: string;
+  type?: {
+    client: number;
+    clock: number;
+  };
+}
+
+export interface SerializedUserState {
+  anchorPos: null | SerializedRelativePosition;
+  awarenessData: Record<string, unknown>;
+  color: string;
+  focusPos: null | SerializedRelativePosition;
+  focusing: boolean;
+  name: string;
+}
+
+export interface RoomEventClient {
+  clientID: number;
+  send: (event: string, data: unknown) => void;
+}
+
+export interface DocumentUpdatePayload {
+  clientID: number;
+  update: string;
+}
+
+export interface AwarenessPayload {
+  clientID: number;
+  state: null | SerializedUserState;
+}
+
+interface RoomState {
+  awareness: Map<number, SerializedUserState>;
+  clients: Map<number, RoomEventClient>;
+  doc: Doc;
+  hasContent: boolean;
+}
+
+const rooms = new Map<string, RoomState>();
+
+const getRoom = (roomId: string): RoomState => {
+  const existing = rooms.get(roomId);
+  if (existing) return existing;
+
+  const room: RoomState = {
+    awareness: new Map(),
+    clients: new Map(),
+    doc: new Doc(),
+    hasContent: false,
+  };
+
+  rooms.set(roomId, room);
+  return room;
+};
+
+const broadcast = (room: RoomState, event: string, data: unknown, excludeClientID?: number) => {
+  for (const [clientID, client] of room.clients) {
+    if (clientID !== excludeClientID) {
+      client.send(event, data);
+    }
+  }
+};
+
+export const addClient = (roomId: string, client: RoomEventClient) => {
+  const room = getRoom(roomId);
+  room.clients.set(client.clientID, client);
+
+  client.send('document-snapshot', {
+    hasContent: room.hasContent,
+    update: room.hasContent ? bytesToBase64(encodeStateAsUpdate(room.doc)) : null,
+  });
+
+  client.send('awareness', {
+    states: Array.from(room.awareness.entries()),
+  });
+};
+
+export const removeClient = (roomId: string, clientID: number) => {
+  const room = getRoom(roomId);
+  room.clients.delete(clientID);
+  room.awareness.delete(clientID);
+
+  broadcast(room, 'awareness', {
+    states: Array.from(room.awareness.entries()),
+  });
+};
+
+export const getSnapshot = (roomId: string) => {
+  const room = getRoom(roomId);
+
+  return {
+    awareness: Array.from(room.awareness.entries()),
+    hasContent: room.hasContent,
+    update: room.hasContent ? bytesToBase64(encodeStateAsUpdate(room.doc)) : null,
+  };
+};
+
+export const resetRoom = (roomId: string) => {
+  const room = rooms.get(roomId);
+  if (!room) return;
+
+  rooms.delete(roomId);
+
+  for (const client of room.clients.values()) {
+    client.send('room-reset', {
+      roomId,
+    });
+  }
+};
+
+export const applyDocumentUpdate = (roomId: string, payload: DocumentUpdatePayload) => {
+  const room = getRoom(roomId);
+  const update = base64ToBytes(payload.update);
+
+  applyUpdate(room.doc, update);
+  room.hasContent = true;
+
+  broadcast(
+    room,
+    'document-update',
+    {
+      clientID: payload.clientID,
+      update: payload.update,
+    },
+    payload.clientID,
+  );
+};
+
+export const applyAwarenessUpdate = (roomId: string, payload: AwarenessPayload) => {
+  const room = getRoom(roomId);
+
+  if (payload.state) {
+    room.awareness.set(payload.clientID, payload.state);
+  } else {
+    room.awareness.delete(payload.clientID);
+  }
+
+  broadcast(room, 'awareness', {
+    states: Array.from(room.awareness.entries()),
+  });
+};

--- a/examples/collaboration-business-demo/src/App.tsx
+++ b/examples/collaboration-business-demo/src/App.tsx
@@ -40,6 +40,7 @@ const users: BusinessUser[] = [
 
 interface ClientPaneProps {
   editable?: boolean;
+  onSynced?: () => void;
   page: PageMetadata;
   role: string;
   roomId: string;
@@ -56,6 +57,7 @@ const collaborationPlugins: EditorPlugin[] = [
 
 const ClientPane = ({
   editable = true,
+  onSynced,
   page,
   role,
   roomId,
@@ -91,6 +93,9 @@ const ClientPane = ({
       onStatusChange: setStatus,
       onSync: (isSynced) => {
         setSyncState(isSynced ? 'synced' : 'syncing');
+        if (isSynced) {
+          onSynced?.();
+        }
       },
       providerFactory,
       shouldBootstrap,
@@ -111,6 +116,7 @@ const ClientPane = ({
     [
       connected,
       editable,
+      onSynced,
       page.id,
       page.workspaceId,
       providerFactory,
@@ -176,16 +182,19 @@ export const App = () => {
   const [showObserver, setShowObserver] = useState(true);
   const [page, setPage] = useState<PageMetadata>();
   const [roomId, setRoomId] = useState('');
+  const [seedReady, setSeedReady] = useState(false);
   const [error, setError] = useState<string>();
   const [sessionKey, setSessionKey] = useState(0);
 
   useEffect(() => {
     setPage(undefined);
     setRoomId('');
+    setSeedReady(false);
     setError(undefined);
 
     fetchPage(workspaceId, activePageId)
-      .then((response) => {
+      .then(async (response) => {
+        await resetRoom(response.roomId);
         setPage(response.page);
         setRoomId(response.roomId);
       })
@@ -198,9 +207,14 @@ export const App = () => {
     setSessionKey((value) => value + 1);
   }, []);
 
+  const markSeedReady = useCallback(() => {
+    setSeedReady(true);
+  }, []);
+
   const resetActiveRoom = useCallback(() => {
     if (!roomId) return;
 
+    setSeedReady(false);
     resetRoom(roomId)
       .then(() => {
         remountClients();
@@ -273,39 +287,40 @@ export const App = () => {
 
         <section className="integration-summary">
           <div>
-            <span>First open</span>
-            <strong>JSON bootstrap only once</strong>
+            <span>Room reset</span>
+            <strong>fresh demo state</strong>
           </div>
           <div>
-            <span>Re-enter</span>
-            <strong>room snapshot hydrate</strong>
+            <span>Alice</span>
+            <strong>seeds initial JSON</strong>
+          </div>
+          <div>
+            <span>Bo and Cara</span>
+            <strong>join same room</strong>
           </div>
           <div>
             <span>Presence</span>
-            <strong>focus, leave, observer</strong>
-          </div>
-          <div>
-            <span>Content nodes</span>
-            <strong>list, table, image, code</strong>
+            <strong>remote cursor only</strong>
           </div>
         </section>
 
         <section className="pane-grid" key={`${roomId}:${sessionKey}`}>
           <ClientPane
+            onSynced={markSeedReady}
             page={page}
-            role="Bootstrap client"
+            role="Seed client"
             roomId={roomId}
             shouldBootstrap
             user={users[0]}
           />
-          {showBo ? (
-            <ClientPane page={page} role="Joining client" roomId={roomId} user={users[1]} />
+          {showBo && seedReady ? (
+            <ClientPane page={page} role="Room peer" roomId={roomId} user={users[1]} />
           ) : null}
-          {showObserver ? (
+          {showObserver && seedReady ? (
             <ClientPane
               editable={false}
               page={page}
-              role="Read-only observer"
+              role="Read-only peer"
               roomId={roomId}
               user={users[2]}
             />

--- a/examples/collaboration-business-demo/src/App.tsx
+++ b/examples/collaboration-business-demo/src/App.tsx
@@ -1,0 +1,317 @@
+import type { Provider } from '@lexical/yjs';
+import { ReactCodeblockPlugin } from '@lobehub/editor/plugins/codeblock';
+import { ReactImagePlugin } from '@lobehub/editor/plugins/image';
+import { ReactListPlugin } from '@lobehub/editor/plugins/list';
+import { ReactTablePlugin } from '@lobehub/editor/plugins/table';
+import type { EditorProps } from '@lobehub/editor/react';
+import { Editor, EditorProvider, useEditor } from '@lobehub/editor/react';
+import type { CSSProperties } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Doc } from 'yjs';
+
+import { BusinessCollaborationProvider } from './BusinessCollaborationProvider';
+import { fetchPage, resetRoom } from './api';
+import { emptyPageContent, getInitialPageContent } from './editorContent';
+import type { BusinessUser, PageMetadata } from './types';
+
+const workspaceId = 'workspace-alpha';
+const pageIds = ['launch-notes', 'roadmap', 'retrospective'] as const;
+
+type CollaborationConfig = Exclude<EditorProps['collaboration'], false | undefined>;
+type EditorPlugin = NonNullable<EditorProps['plugins']>[number];
+
+const users: BusinessUser[] = [
+  {
+    color: '#2563eb',
+    id: 'u_alice',
+    name: 'Alice',
+  },
+  {
+    color: '#16a34a',
+    id: 'u_bo',
+    name: 'Bo',
+  },
+  {
+    color: '#9333ea',
+    id: 'u_cara',
+    name: 'Cara',
+  },
+];
+
+interface ClientPaneProps {
+  editable?: boolean;
+  page: PageMetadata;
+  role: string;
+  roomId: string;
+  shouldBootstrap?: boolean;
+  user: BusinessUser;
+}
+
+const collaborationPlugins: EditorPlugin[] = [
+  ReactListPlugin,
+  ReactTablePlugin,
+  ReactImagePlugin,
+  ReactCodeblockPlugin,
+];
+
+const ClientPane = ({
+  editable = true,
+  page,
+  role,
+  roomId,
+  shouldBootstrap = false,
+  user,
+}: ClientPaneProps) => {
+  const editor = useEditor();
+  const [connected, setConnected] = useState(true);
+  const [focusState, setFocusState] = useState('blurred');
+  const [status, setStatus] = useState('idle');
+  const [syncState, setSyncState] = useState('not synced');
+  const yjsDocMap = useMemo(() => new Map([[roomId, new Doc()]]), [roomId]);
+  const initialContent = shouldBootstrap ? getInitialPageContent(page.id) : emptyPageContent;
+
+  const providerFactory = useMemo(
+    () =>
+      ((id: string, docMap: Map<string, Doc>): Provider => {
+        const doc = docMap.get(id);
+
+        if (!doc) {
+          throw new Error(`Missing Y.Doc for room ${id}`);
+        }
+
+        return new BusinessCollaborationProvider(id, doc);
+      }) satisfies CollaborationConfig['providerFactory'],
+    [],
+  );
+
+  const collaboration = useMemo<CollaborationConfig>(
+    () => ({
+      connect: connected,
+      id: roomId,
+      onStatusChange: setStatus,
+      onSync: (isSynced) => {
+        setSyncState(isSynced ? 'synced' : 'syncing');
+      },
+      providerFactory,
+      shouldBootstrap,
+      user: {
+        awarenessData: {
+          editable,
+          pageId: page.id,
+          role,
+          userId: user.id,
+          workspaceId: page.workspaceId,
+        },
+        color: user.color,
+        focusing: connected,
+        name: user.name,
+      },
+      yjsDocMap,
+    }),
+    [
+      connected,
+      editable,
+      page.id,
+      page.workspaceId,
+      providerFactory,
+      role,
+      roomId,
+      shouldBootstrap,
+      user,
+      yjsDocMap,
+    ],
+  );
+
+  return (
+    <section className="client-pane">
+      <div className="client-pane-header">
+        <div>
+          <div className="client-name" style={{ '--user-color': user.color } as CSSProperties}>
+            {user.name}
+          </div>
+          <div className="client-meta">
+            {role} · {editable ? 'editable' : 'read-only'} · {focusState}
+          </div>
+        </div>
+        <div className="client-actions">
+          <div className="client-status">
+            <span>{connected ? status : 'detached'}</span>
+            <span>{syncState}</span>
+          </div>
+          <button
+            className="small-button"
+            onClick={() => {
+              setConnected((value) => !value);
+              setStatus(connected ? 'detached' : 'idle');
+            }}
+            type="button"
+          >
+            {connected ? 'Disconnect' : 'Reconnect'}
+          </button>
+        </div>
+      </div>
+      <Editor
+        className="business-editor"
+        collaboration={collaboration}
+        content={initialContent}
+        editable={editable}
+        editor={editor}
+        onBlur={() => {
+          setFocusState('blurred');
+        }}
+        onFocus={() => {
+          setFocusState('focused');
+        }}
+        placeholder="Write page content..."
+        plugins={collaborationPlugins}
+        type="json"
+      />
+    </section>
+  );
+};
+
+export const App = () => {
+  const [activePageId, setActivePageId] = useState<(typeof pageIds)[number]>('launch-notes');
+  const [showBo, setShowBo] = useState(true);
+  const [showObserver, setShowObserver] = useState(true);
+  const [page, setPage] = useState<PageMetadata>();
+  const [roomId, setRoomId] = useState('');
+  const [error, setError] = useState<string>();
+  const [sessionKey, setSessionKey] = useState(0);
+
+  useEffect(() => {
+    setPage(undefined);
+    setRoomId('');
+    setError(undefined);
+
+    fetchPage(workspaceId, activePageId)
+      .then((response) => {
+        setPage(response.page);
+        setRoomId(response.roomId);
+      })
+      .catch((error_: unknown) => {
+        setError(error_ instanceof Error ? error_.message : 'Failed to load page metadata');
+      });
+  }, [activePageId]);
+
+  const remountClients = useCallback(() => {
+    setSessionKey((value) => value + 1);
+  }, []);
+
+  const resetActiveRoom = useCallback(() => {
+    if (!roomId) return;
+
+    resetRoom(roomId)
+      .then(() => {
+        remountClients();
+      })
+      .catch((error_: unknown) => {
+        setError(error_ instanceof Error ? error_.message : 'Failed to reset room');
+      });
+  }, [remountClients, roomId]);
+
+  if (error) {
+    return <main className="app-shell error-state">{error}</main>;
+  }
+
+  if (!page || !roomId) {
+    return <main className="app-shell loading-state">Loading collaboration room...</main>;
+  }
+
+  return (
+    <EditorProvider>
+      <main className="app-shell">
+        <header className="topbar">
+          <div>
+            <div className="eyebrow">Workspace Page Collaboration MVP</div>
+            <h1>{page.title}</h1>
+          </div>
+          <div className="room-chip">{roomId}</div>
+        </header>
+
+        <section className="control-bar">
+          <div className="segmented">
+            {pageIds.map((pageId) => (
+              <button
+                className={pageId === activePageId ? 'active' : ''}
+                key={pageId}
+                onClick={() => {
+                  setActivePageId(pageId);
+                  setSessionKey((value) => value + 1);
+                }}
+                type="button"
+              >
+                {pageId}
+              </button>
+            ))}
+          </div>
+          <button className="control-button" onClick={remountClients} type="button">
+            Re-enter clients
+          </button>
+          <button
+            className="control-button"
+            onClick={() => {
+              setShowBo((value) => !value);
+            }}
+            type="button"
+          >
+            {showBo ? 'Remove Bo' : 'Rejoin Bo'}
+          </button>
+          <button
+            className="control-button"
+            onClick={() => {
+              setShowObserver((value) => !value);
+            }}
+            type="button"
+          >
+            {showObserver ? 'Hide observer' : 'Show observer'}
+          </button>
+          <button className="control-button danger" onClick={resetActiveRoom} type="button">
+            Reset room
+          </button>
+        </section>
+
+        <section className="integration-summary">
+          <div>
+            <span>First open</span>
+            <strong>JSON bootstrap only once</strong>
+          </div>
+          <div>
+            <span>Re-enter</span>
+            <strong>room snapshot hydrate</strong>
+          </div>
+          <div>
+            <span>Presence</span>
+            <strong>focus, leave, observer</strong>
+          </div>
+          <div>
+            <span>Content nodes</span>
+            <strong>list, table, image, code</strong>
+          </div>
+        </section>
+
+        <section className="pane-grid" key={`${roomId}:${sessionKey}`}>
+          <ClientPane
+            page={page}
+            role="Bootstrap client"
+            roomId={roomId}
+            shouldBootstrap
+            user={users[0]}
+          />
+          {showBo ? (
+            <ClientPane page={page} role="Joining client" roomId={roomId} user={users[1]} />
+          ) : null}
+          {showObserver ? (
+            <ClientPane
+              editable={false}
+              page={page}
+              role="Read-only observer"
+              roomId={roomId}
+              user={users[2]}
+            />
+          ) : null}
+        </section>
+      </main>
+    </EditorProvider>
+  );
+};

--- a/examples/collaboration-business-demo/src/BusinessCollaborationProvider.test.ts
+++ b/examples/collaboration-business-demo/src/BusinessCollaborationProvider.test.ts
@@ -1,0 +1,88 @@
+/// <reference types="vitest" />
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { Doc, XmlElement, XmlText, applyUpdate, encodeStateAsUpdate } from 'yjs';
+
+import { BusinessCollaborationProvider } from './BusinessCollaborationProvider';
+import { base64ToBytes, bytesToBase64 } from './codec';
+
+class FakeEventSource {
+  private readonly listeners = new Map<string, Set<EventListenerOrEventListenerObject>>();
+
+  constructor(readonly url: string) {}
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    const listeners = this.listeners.get(type) ?? new Set<EventListenerOrEventListenerObject>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  close() {}
+}
+
+const createParagraphElement = (text: string) => {
+  const paragraph = new XmlElement('p');
+  paragraph.insert(0, [new XmlText(text)]);
+
+  return paragraph;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe('BusinessCollaborationProvider', () => {
+  it('publishes local Yjs state after reconnecting with offline edits', async () => {
+    const serverDoc = new Doc();
+    serverDoc.get('root-v2', XmlElement).insert(0, [createParagraphElement('server')]);
+
+    let snapshotUpdate: null | string = bytesToBase64(encodeStateAsUpdate(serverDoc));
+    const postedUpdates: string[] = [];
+
+    vi.stubGlobal('EventSource', FakeEventSource);
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = String(input);
+
+        if (url.includes('/snapshot')) {
+          return Response.json({
+            awareness: [],
+            hasContent: Boolean(snapshotUpdate),
+            update: snapshotUpdate,
+          });
+        }
+
+        if (url.includes('/update')) {
+          const payload = JSON.parse(init?.body as string) as { update: string };
+          postedUpdates.push(payload.update);
+          applyUpdate(serverDoc, base64ToBytes(payload.update));
+          snapshotUpdate = bytesToBase64(encodeStateAsUpdate(serverDoc));
+
+          return Response.json({ ok: true });
+        }
+
+        if (url.includes('/awareness')) {
+          return Response.json({ ok: true });
+        }
+
+        return new Response(null, { status: 404 });
+      }),
+    );
+
+    const localDoc = new Doc();
+    const provider = new BusinessCollaborationProvider('room-1', localDoc);
+
+    await provider.connect();
+    expect(postedUpdates).toHaveLength(0);
+
+    provider.disconnect();
+    localDoc.get('root-v2', XmlElement).insert(1, [createParagraphElement('offline')]);
+
+    await provider.connect();
+
+    expect(postedUpdates).toHaveLength(1);
+    expect(serverDoc.get('root-v2', XmlElement).toString()).toContain('offline');
+  });
+});

--- a/examples/collaboration-business-demo/src/BusinessCollaborationProvider.ts
+++ b/examples/collaboration-business-demo/src/BusinessCollaborationProvider.ts
@@ -1,0 +1,203 @@
+import type { Provider, UserState } from '@lexical/yjs';
+import { Doc, XmlElement, applyUpdate, encodeStateAsUpdate } from 'yjs';
+
+import {
+  createRoomEventSource,
+  fetchRoomSnapshot,
+  postAwarenessUpdate,
+  postDocumentUpdate,
+} from './api';
+import { BusinessAwareness, serializeUserState } from './awareness';
+import { base64ToBytes, bytesToBase64 } from './codec';
+import type {
+  AwarenessEventPayload,
+  DocumentSnapshotEventPayload,
+  DocumentUpdateEventPayload,
+  RoomResetEventPayload,
+} from './types';
+
+const serverUpdateOrigin = Symbol('server-update');
+
+const docHasCollaborationContent = (doc: Doc) => doc.get('root-v2', XmlElement).length > 0;
+
+type ProviderEventType = 'reload' | 'status' | 'sync' | 'update';
+type ProviderListener =
+  | ((_doc: Doc) => void)
+  | ((_event: unknown) => void)
+  | ((_event: { status: string }) => void)
+  | ((_isSynced: boolean) => void);
+
+export class BusinessCollaborationProvider implements Provider {
+  readonly awareness: BusinessAwareness;
+  private connected = false;
+  private eventSource: EventSource | undefined;
+  private readonly reloadListeners = new Set<(_doc: Doc) => void>();
+  private readonly statusListeners = new Set<(_event: { status: string }) => void>();
+  private readonly syncListeners = new Set<(_isSynced: boolean) => void>();
+  private readonly updateListeners = new Set<(_event: unknown) => void>();
+
+  constructor(
+    private readonly roomId: string,
+    private readonly doc: Doc,
+  ) {
+    this.awareness = new BusinessAwareness(doc.clientID, this.publishAwareness);
+  }
+
+  async connect() {
+    if (this.connected) return;
+
+    this.connected = true;
+    this.doc.on('update', this.handleLocalDocumentUpdate);
+    this.emitStatus('connecting');
+
+    const snapshot = await fetchRoomSnapshot(this.roomId);
+
+    if (!this.connected) return;
+
+    this.openEventSource();
+
+    if (snapshot.update) {
+      applyUpdate(this.doc, base64ToBytes(snapshot.update), serverUpdateOrigin);
+    } else if (docHasCollaborationContent(this.doc)) {
+      await this.publishDocumentUpdate(encodeStateAsUpdate(this.doc));
+    }
+
+    this.awareness.applyRemoteStates(snapshot.awareness);
+    this.publishAwareness(this.awareness.getLocalState());
+    this.emitStatus('connected');
+    this.emitSync(true);
+  }
+
+  disconnect() {
+    if (!this.connected) return;
+
+    this.connected = false;
+    this.awareness.setLocalState(null);
+    this.eventSource?.close();
+    this.eventSource = undefined;
+    this.doc.off('update', this.handleLocalDocumentUpdate);
+    this.emitStatus('disconnected');
+  }
+
+  off(type: ProviderEventType, callback: ProviderListener) {
+    if (type === 'sync') {
+      this.syncListeners.delete(callback as (isSynced: boolean) => void);
+      return;
+    }
+
+    if (type === 'status') {
+      this.statusListeners.delete(callback as (event: { status: string }) => void);
+      return;
+    }
+
+    if (type === 'reload') {
+      this.reloadListeners.delete(callback as (doc: Doc) => void);
+      return;
+    }
+
+    this.updateListeners.delete(callback as (event: unknown) => void);
+  }
+
+  on(type: ProviderEventType, callback: ProviderListener) {
+    if (type === 'sync') {
+      this.syncListeners.add(callback as (isSynced: boolean) => void);
+      return;
+    }
+
+    if (type === 'status') {
+      this.statusListeners.add(callback as (event: { status: string }) => void);
+      return;
+    }
+
+    if (type === 'reload') {
+      this.reloadListeners.add(callback as (doc: Doc) => void);
+      return;
+    }
+
+    this.updateListeners.add(callback as (event: unknown) => void);
+  }
+
+  private emitStatus(status: string) {
+    for (const listener of this.statusListeners) {
+      listener({ status });
+    }
+  }
+
+  private emitSync(isSynced: boolean) {
+    for (const listener of this.syncListeners) {
+      listener(isSynced);
+    }
+  }
+
+  private readonly handleLocalDocumentUpdate = (update: Uint8Array, origin: unknown) => {
+    if (!this.connected || origin === serverUpdateOrigin) return;
+
+    for (const listener of this.updateListeners) {
+      listener(update);
+    }
+
+    void this.publishDocumentUpdate(update).catch((error: unknown) => {
+      console.error(error);
+      this.emitStatus('error');
+    });
+  };
+
+  private openEventSource() {
+    const eventSource = createRoomEventSource(this.roomId, this.doc.clientID);
+    this.eventSource = eventSource;
+
+    eventSource.addEventListener('document-snapshot', (event) => {
+      const payload = JSON.parse(event.data) as DocumentSnapshotEventPayload;
+      if (!payload.update) return;
+
+      applyUpdate(this.doc, base64ToBytes(payload.update), serverUpdateOrigin);
+    });
+
+    eventSource.addEventListener('room-reset', (event) => {
+      const payload = JSON.parse(event.data) as RoomResetEventPayload;
+      if (payload.roomId === this.roomId) {
+        this.emitStatus('room reset');
+        this.emitSync(false);
+      }
+    });
+
+    eventSource.addEventListener('document-update', (event) => {
+      const payload = JSON.parse(event.data) as DocumentUpdateEventPayload;
+      if (payload.clientID === this.doc.clientID) return;
+
+      applyUpdate(this.doc, base64ToBytes(payload.update), serverUpdateOrigin);
+    });
+
+    eventSource.addEventListener('awareness', (event) => {
+      const payload = JSON.parse(event.data) as AwarenessEventPayload;
+      this.awareness.applyRemoteStates(payload.states);
+    });
+
+    eventSource.addEventListener('error', () => {
+      this.emitStatus('reconnecting');
+      this.emitSync(false);
+    });
+
+    eventSource.addEventListener('open', () => {
+      this.emitStatus('connected');
+      this.emitSync(true);
+    });
+  }
+
+  private async publishDocumentUpdate(update: Uint8Array) {
+    await postDocumentUpdate(this.roomId, this.doc.clientID, bytesToBase64(update));
+  }
+
+  private readonly publishAwareness = (state: null | UserState) => {
+    if (!this.connected) return;
+
+    void postAwarenessUpdate(
+      this.roomId,
+      this.doc.clientID,
+      state ? serializeUserState(state) : null,
+    ).catch((error: unknown) => {
+      console.error(error);
+      this.emitStatus('error');
+    });
+  };
+}

--- a/examples/collaboration-business-demo/src/BusinessCollaborationProvider.ts
+++ b/examples/collaboration-business-demo/src/BusinessCollaborationProvider.ts
@@ -1,5 +1,11 @@
 import type { Provider, UserState } from '@lexical/yjs';
-import { Doc, XmlElement, applyUpdate, encodeStateAsUpdate } from 'yjs';
+import {
+  Doc,
+  applyUpdate,
+  diffUpdate,
+  encodeStateAsUpdate,
+  encodeStateVectorFromUpdate,
+} from 'yjs';
 
 import {
   createRoomEventSource,
@@ -18,7 +24,7 @@ import type {
 
 const serverUpdateOrigin = Symbol('server-update');
 
-const docHasCollaborationContent = (doc: Doc) => doc.get('root-v2', XmlElement).length > 0;
+const updateHasContent = (update: Uint8Array) => update.byteLength > 2;
 
 type ProviderEventType = 'reload' | 'status' | 'sync' | 'update';
 type ProviderListener =
@@ -50,6 +56,10 @@ export class BusinessCollaborationProvider implements Provider {
     this.doc.on('update', this.handleLocalDocumentUpdate);
     this.emitStatus('connecting');
 
+    const localUpdate = encodeStateAsUpdate(this.doc);
+    let updateToPublish: Uint8Array | undefined = updateHasContent(localUpdate)
+      ? localUpdate
+      : undefined;
     const snapshot = await fetchRoomSnapshot(this.roomId);
 
     if (!this.connected) return;
@@ -57,9 +67,21 @@ export class BusinessCollaborationProvider implements Provider {
     this.openEventSource();
 
     if (snapshot.update) {
-      applyUpdate(this.doc, base64ToBytes(snapshot.update), serverUpdateOrigin);
-    } else if (docHasCollaborationContent(this.doc)) {
-      await this.publishDocumentUpdate(encodeStateAsUpdate(this.doc));
+      const remoteUpdate = base64ToBytes(snapshot.update);
+
+      if (updateToPublish) {
+        const missingLocalUpdate = diffUpdate(
+          localUpdate,
+          encodeStateVectorFromUpdate(remoteUpdate),
+        );
+        updateToPublish = updateHasContent(missingLocalUpdate) ? missingLocalUpdate : undefined;
+      }
+
+      applyUpdate(this.doc, remoteUpdate, serverUpdateOrigin);
+    }
+
+    if (updateToPublish) {
+      await this.publishDocumentUpdate(updateToPublish);
     }
 
     this.awareness.applyRemoteStates(snapshot.awareness);

--- a/examples/collaboration-business-demo/src/api.ts
+++ b/examples/collaboration-business-demo/src/api.ts
@@ -1,0 +1,74 @@
+import type { PageResponse, RoomSnapshot, SerializedUserState } from './types';
+
+export const apiBase = '';
+
+export const fetchPage = async (workspaceId: string, pageId: string) => {
+  const response = await fetch(`${apiBase}/api/workspaces/${workspaceId}/pages/${pageId}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch page metadata: ${response.status}`);
+  }
+
+  return response.json() as Promise<PageResponse>;
+};
+
+export const fetchRoomSnapshot = async (roomId: string) => {
+  const response = await fetch(`${apiBase}/api/rooms/${encodeURIComponent(roomId)}/snapshot`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch room snapshot: ${response.status}`);
+  }
+
+  return response.json() as Promise<RoomSnapshot>;
+};
+
+export const postDocumentUpdate = async (roomId: string, clientID: number, update: string) => {
+  const response = await fetch(`${apiBase}/api/rooms/${encodeURIComponent(roomId)}/update`, {
+    body: JSON.stringify({
+      clientID,
+      update,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to post document update: ${response.status}`);
+  }
+};
+
+export const postAwarenessUpdate = async (
+  roomId: string,
+  clientID: number,
+  state: null | SerializedUserState,
+) => {
+  const response = await fetch(`${apiBase}/api/rooms/${encodeURIComponent(roomId)}/awareness`, {
+    body: JSON.stringify({
+      clientID,
+      state,
+    }),
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    method: 'POST',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to post awareness update: ${response.status}`);
+  }
+};
+
+export const createRoomEventSource = (roomId: string, clientID: number) =>
+  new EventSource(`${apiBase}/api/rooms/${encodeURIComponent(roomId)}/events?clientID=${clientID}`);
+
+export const resetRoom = async (roomId: string) => {
+  const response = await fetch(`${apiBase}/api/rooms/${encodeURIComponent(roomId)}`, {
+    method: 'DELETE',
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to reset room: ${response.status}`);
+  }
+};

--- a/examples/collaboration-business-demo/src/awareness.ts
+++ b/examples/collaboration-business-demo/src/awareness.ts
@@ -1,0 +1,107 @@
+import type { ProviderAwareness, UserState } from '@lexical/yjs';
+import { type RelativePosition, createRelativePositionFromJSON, relativePositionToJSON } from 'yjs';
+
+import type { SerializedRelativePosition, SerializedUserState } from './types';
+
+export const serializeRelativePosition = (
+  position: null | RelativePosition,
+): null | SerializedRelativePosition => {
+  if (!position) return null;
+
+  return relativePositionToJSON(position) as SerializedRelativePosition;
+};
+
+export const deserializeRelativePosition = (
+  position: null | SerializedRelativePosition,
+): null | RelativePosition => {
+  if (!position) return null;
+
+  return createRelativePositionFromJSON(position);
+};
+
+export const serializeUserState = (state: UserState): SerializedUserState => ({
+  anchorPos: serializeRelativePosition(state.anchorPos),
+  awarenessData: state.awarenessData as Record<string, unknown>,
+  color: state.color,
+  focusPos: serializeRelativePosition(state.focusPos),
+  focusing: state.focusing,
+  name: state.name,
+});
+
+export const deserializeUserState = (state: SerializedUserState): UserState => ({
+  anchorPos: deserializeRelativePosition(state.anchorPos),
+  awarenessData: state.awarenessData,
+  color: state.color,
+  focusPos: deserializeRelativePosition(state.focusPos),
+  focusing: state.focusing,
+  name: state.name,
+});
+
+export class BusinessAwareness implements ProviderAwareness {
+  private localState: null | UserState = null;
+  private readonly remoteStates = new Map<number, UserState>();
+  private readonly updateListeners = new Set<() => void>();
+
+  constructor(
+    private readonly clientID: number,
+    private readonly publishLocalState: (state: null | UserState) => void,
+  ) {}
+
+  applyRemoteStates(states: Array<[number, SerializedUserState]>) {
+    this.remoteStates.clear();
+
+    for (const [clientID, state] of states) {
+      if (clientID !== this.clientID) {
+        this.remoteStates.set(clientID, deserializeUserState(state));
+      }
+    }
+
+    this.emitUpdate();
+  }
+
+  getLocalState = () => this.localState;
+
+  getStates = () => {
+    const states = new Map(this.remoteStates);
+
+    if (this.localState) {
+      states.set(this.clientID, this.localState);
+    }
+
+    return states;
+  };
+
+  off = (_type: 'update', callback: () => void) => {
+    this.updateListeners.delete(callback);
+  };
+
+  on = (_type: 'update', callback: () => void) => {
+    this.updateListeners.add(callback);
+  };
+
+  setLocalState = (state: null | UserState) => {
+    this.localState = state;
+    this.publishLocalState(state);
+    this.emitUpdate();
+  };
+
+  setLocalStateField = (field: string, value: unknown) => {
+    this.setLocalState({
+      ...(this.localState ?? {
+        anchorPos: null,
+        awarenessData: {},
+        color: '#1677ff',
+        focusPos: null,
+        focusing: true,
+        name: 'Local collaborator',
+      }),
+      [field]: value,
+    });
+  };
+
+  private emitUpdate() {
+    for (const listener of this.updateListeners) {
+      listener();
+    }
+  }
+}

--- a/examples/collaboration-business-demo/src/codec.ts
+++ b/examples/collaboration-business-demo/src/codec.ts
@@ -1,0 +1,20 @@
+export const bytesToBase64 = (bytes: Uint8Array) => {
+  let binary = '';
+
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+
+  return btoa(binary);
+};
+
+export const base64ToBytes = (value: string) => {
+  const binary = atob(value);
+  const bytes = new Uint8Array(binary.length);
+
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+
+  return bytes;
+};

--- a/examples/collaboration-business-demo/src/editorContent.ts
+++ b/examples/collaboration-business-demo/src/editorContent.ts
@@ -1,0 +1,175 @@
+const text = (value: string, format = 0) => ({
+  detail: 0,
+  format,
+  mode: 'normal',
+  style: '',
+  text: value,
+  type: 'text',
+  version: 1,
+});
+
+const paragraph = (value = '') => ({
+  children: value ? [text(value)] : [],
+  direction: null,
+  format: '',
+  indent: 0,
+  textFormat: 0,
+  textStyle: '',
+  type: 'paragraph',
+  version: 1,
+});
+
+const heading = (value: string, tag: 'h1' | 'h2' | 'h3' = 'h1') => ({
+  children: [text(value, tag === 'h1' ? 1 : 0)],
+  direction: null,
+  format: '',
+  indent: 0,
+  tag,
+  type: 'heading',
+  version: 1,
+});
+
+const listItem = (value: string, index: number) => ({
+  children: [text(value)],
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  type: 'listitem',
+  value: index,
+  version: 1,
+});
+
+const bulletList = (items: string[]) => ({
+  children: items.map((item, index) => listItem(item, index + 1)),
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  listType: 'bullet',
+  start: 1,
+  tag: 'ul',
+  type: 'list',
+  version: 1,
+});
+
+const tableCell = (value: string, headerState = 0) => ({
+  backgroundColor: null,
+  children: [paragraph(value)],
+  colSpan: 1,
+  direction: 'ltr',
+  format: '',
+  headerState,
+  indent: 0,
+  rowSpan: 1,
+  type: 'tablecell',
+  version: 1,
+});
+
+const tableRow = (cells: Array<{ header?: boolean; value: string }>) => ({
+  children: cells.map((cell) => tableCell(cell.value, cell.header ? 3 : 0)),
+  direction: 'ltr',
+  format: '',
+  height: null,
+  indent: 0,
+  type: 'tablerow',
+  version: 1,
+});
+
+const table = () => ({
+  children: [
+    tableRow([
+      { header: true, value: 'Area' },
+      { header: true, value: 'Owner' },
+      { header: true, value: 'Status' },
+    ]),
+    tableRow([{ value: 'Editor binding' }, { value: 'Alice' }, { value: 'Ready' }]),
+    tableRow([{ value: 'Persistence relay' }, { value: 'Bo' }, { value: 'Validating' }]),
+  ],
+  colWidths: [180, 160, 180],
+  direction: 'ltr',
+  format: '',
+  indent: 0,
+  type: 'table',
+  version: 1,
+});
+
+const blockImage = () => ({
+  altText: 'Generated product board placeholder',
+  height: 160,
+  maxWidth: 640,
+  src: 'https://dummyimage.com/960x320/e2e8f0/334155&text=Workspace+Artifact',
+  status: 'uploaded',
+  type: 'block-image',
+  version: 1,
+  width: 480,
+});
+
+const codeBlock = () => ({
+  children: [],
+  code: 'const roomId = `${workspaceId}:${pageId}`;\nconst provider = providerFactory(roomId, yjsDocMap);',
+  codeTheme: 'default',
+  direction: null,
+  format: '',
+  indent: 0,
+  language: 'typescript',
+  options: {
+    indentWithTabs: false,
+    lineNumbers: false,
+    tabSize: 2,
+  },
+  type: 'code',
+  version: 1,
+});
+
+const document = (children: unknown[]) => ({
+  root: {
+    children,
+    direction: null,
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+});
+
+export const emptyPageContent = document([paragraph()]);
+
+export const pageContents = {
+  'launch-notes': document([
+    heading('Q3 Launch Notes'),
+    paragraph(
+      'This local demo mirrors the intended business integration: workspace page metadata creates a room, the business shell creates a provider, and the editor owns the Lexical/Yjs binding.',
+    ),
+    bulletList([
+      'Bootstrap only when the collaboration room is empty.',
+      'Joining clients hydrate from the room snapshot.',
+      'Presence and cursor state travel through awareness.',
+    ]),
+    table(),
+    blockImage(),
+    codeBlock(),
+    paragraph(
+      'Open all panes, focus either editable client, and edit from both sides to validate document sync and remote cursor presence.',
+    ),
+  ]),
+  'retrospective': document([
+    heading('Release Retrospective'),
+    paragraph('This page validates room switching and a different persisted Y.Doc snapshot.'),
+    bulletList(['What changed', 'What broke', 'What needs follow-up']),
+    table(),
+    paragraph('Switch back to launch notes to confirm old room cleanup and new room hydrate.'),
+  ]),
+  'roadmap': document([
+    heading('Workspace Roadmap'),
+    paragraph(
+      'This page validates that each workspace page has an independent collaboration room.',
+    ),
+    bulletList(['Foundation', 'Presence', 'Persistence', 'Production hardening']),
+    codeBlock(),
+    paragraph(
+      'Use remount controls to simulate re-entering the same page without overwriting Y.Doc.',
+    ),
+  ]),
+} as const;
+
+export const getInitialPageContent = (pageId: string) =>
+  pageContents[pageId as keyof typeof pageContents] ?? pageContents['launch-notes'];

--- a/examples/collaboration-business-demo/src/lexical-table-observer.d.ts
+++ b/examples/collaboration-business-demo/src/lexical-table-observer.d.ts
@@ -1,0 +1,9 @@
+declare module '@lexical/table/LexicalTableObserver' {
+  import type { TableDOMCell } from '@lexical/table';
+
+  export interface TableDOMTable {
+    columns: number;
+    domRows: Array<Array<TableDOMCell | undefined> | undefined>;
+    rows: number;
+  }
+}

--- a/examples/collaboration-business-demo/src/main.tsx
+++ b/examples/collaboration-business-demo/src/main.tsx
@@ -1,0 +1,12 @@
+import { createRoot } from 'react-dom/client';
+
+import { App } from './App';
+import './styles.css';
+
+const root = document.querySelector('#root');
+
+if (!root) {
+  throw new Error('Missing root element');
+}
+
+createRoot(root).render(<App />);

--- a/examples/collaboration-business-demo/src/styles.css
+++ b/examples/collaboration-business-demo/src/styles.css
@@ -1,0 +1,253 @@
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: #f7f8fa;
+  color: #171717;
+  font-family:
+    Inter,
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    sans-serif;
+}
+
+.app-shell {
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+  gap: 20px;
+  padding: 24px;
+}
+
+.loading-state,
+.error-state {
+  align-items: center;
+  justify-content: center;
+  color: #525866;
+}
+
+.topbar {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.eyebrow {
+  color: #64748b;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-transform: uppercase;
+}
+
+h1 {
+  margin: 4px 0 0;
+  font-size: 28px;
+  line-height: 1.2;
+}
+
+.room-chip {
+  border: 1px solid #d6dbe3;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #475569;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  font-size: 12px;
+  padding: 8px 10px;
+}
+
+.integration-summary {
+  display: grid;
+  overflow: hidden;
+  border: 1px solid #e1e5eb;
+  border-radius: 8px;
+  background: #ffffff;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.integration-summary > div {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 14px 16px;
+}
+
+.integration-summary > div + div {
+  border-left: 1px solid #e1e5eb;
+}
+
+.integration-summary span {
+  color: #64748b;
+  font-size: 12px;
+}
+
+.integration-summary strong {
+  font-size: 14px;
+  font-weight: 700;
+}
+
+.pane-grid {
+  display: grid;
+  align-items: stretch;
+  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(360px, 1fr));
+}
+
+.control-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+}
+
+.segmented {
+  display: inline-flex;
+  overflow: hidden;
+  border: 1px solid #d6dbe3;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.segmented button,
+.control-button,
+.small-button {
+  border: 0;
+  background: transparent;
+  color: #334155;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+}
+
+.segmented button {
+  min-height: 36px;
+  padding: 0 12px;
+}
+
+.segmented button + button {
+  border-left: 1px solid #d6dbe3;
+}
+
+.segmented button.active {
+  background: #111827;
+  color: #ffffff;
+}
+
+.control-button,
+.small-button {
+  min-height: 36px;
+  border: 1px solid #d6dbe3;
+  border-radius: 8px;
+  background: #ffffff;
+  padding: 0 12px;
+}
+
+.control-button.danger {
+  border-color: #fecaca;
+  color: #b91c1c;
+}
+
+.client-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.client-pane {
+  display: flex;
+  min-height: 580px;
+  flex-direction: column;
+  overflow: hidden;
+  border: 1px solid #dfe4ec;
+  border-radius: 8px;
+  background: #ffffff;
+}
+
+.client-pane-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  border-bottom: 1px solid #edf0f4;
+  padding: 14px 16px;
+}
+
+.client-name {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+}
+
+.client-name::before {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--user-color);
+  content: '';
+}
+
+.client-meta {
+  margin-top: 2px;
+  color: #64748b;
+  font-size: 12px;
+}
+
+.client-status {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 6px;
+}
+
+.client-status span {
+  border: 1px solid #e1e5eb;
+  border-radius: 999px;
+  background: #f8fafc;
+  color: #475569;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+
+.business-editor {
+  min-height: 520px;
+  flex: 1;
+  outline: none;
+  padding: 20px 24px;
+}
+
+.business-editor h1 {
+  margin: 0 0 12px;
+  font-size: 24px;
+}
+
+.business-editor p {
+  margin: 0 0 10px;
+}
+
+@media (max-width: 900px) {
+  .app-shell {
+    padding: 16px;
+  }
+
+  .topbar {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .integration-summary,
+  .pane-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .integration-summary > div + div {
+    border-top: 1px solid #e1e5eb;
+    border-left: 0;
+  }
+}

--- a/examples/collaboration-business-demo/src/types.ts
+++ b/examples/collaboration-business-demo/src/types.ts
@@ -1,0 +1,66 @@
+import type { UserState } from '@lexical/yjs';
+
+export interface PageMetadata {
+  id: string;
+  title: string;
+  workspaceId: string;
+}
+
+export interface PageResponse {
+  page: PageMetadata;
+  roomId: string;
+}
+
+export interface SerializedRelativePosition {
+  assoc?: number;
+  item?: {
+    client: number;
+    clock: number;
+  };
+  tname?: string;
+  type?: {
+    client: number;
+    clock: number;
+  };
+}
+
+export interface SerializedUserState {
+  anchorPos: null | SerializedRelativePosition;
+  awarenessData: Record<string, unknown>;
+  color: string;
+  focusPos: null | SerializedRelativePosition;
+  focusing: boolean;
+  name: string;
+}
+
+export interface RoomSnapshot {
+  awareness: Array<[number, SerializedUserState]>;
+  hasContent: boolean;
+  update: null | string;
+}
+
+export interface AwarenessEventPayload {
+  states: Array<[number, SerializedUserState]>;
+}
+
+export interface DocumentUpdateEventPayload {
+  clientID: number;
+  update: string;
+}
+
+export interface DocumentSnapshotEventPayload {
+  hasContent: boolean;
+  update: null | string;
+}
+
+export interface RoomResetEventPayload {
+  roomId: string;
+}
+
+export interface BusinessUser {
+  color: string;
+  id: string;
+  name: string;
+}
+
+export type AwarenessState = UserState;

--- a/examples/collaboration-business-demo/tsconfig.json
+++ b/examples/collaboration-business-demo/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "esModuleInterop": true,
+    "jsx": "react-jsx",
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node", "vite/client"],
+    "paths": {
+      "@/*": ["../../src/*"],
+      "@lobehub/editor/*": ["../../src/*"],
+      "@lobehub/editor": ["../../src/index.ts"],
+      "@lobehub/editor/react": ["../../src/react/index.ts"]
+    }
+  },
+  "include": [
+    "../../src/global.d.ts",
+    "../../src/types",
+    "server",
+    "scripts",
+    "src",
+    "vite.config.ts"
+  ]
+}

--- a/examples/collaboration-business-demo/vite.config.ts
+++ b/examples/collaboration-business-demo/vite.config.ts
@@ -1,0 +1,40 @@
+import react from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
+import { defineConfig } from 'vite';
+
+const repoRoot = resolve(__dirname, '../..');
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: [
+      {
+        find: /^@lobehub\/editor\/(.+)$/,
+        replacement: `${resolve(repoRoot, 'src')}/$1`,
+      },
+      {
+        find: '@lobehub/editor/react',
+        replacement: resolve(repoRoot, 'src/react/index.ts'),
+      },
+      {
+        find: /^@lobehub\/editor$/,
+        replacement: resolve(repoRoot, 'src/index.ts'),
+      },
+      {
+        find: '@',
+        replacement: resolve(repoRoot, 'src'),
+      },
+    ],
+    dedupe: ['react', 'react-dom'],
+  },
+  server: {
+    fs: {
+      allow: [repoRoot, __dirname],
+    },
+    host: '0.0.0.0',
+    port: 5174,
+    proxy: {
+      '/api': 'http://localhost:8797',
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@lexical/selection": "0.42.0",
     "@lexical/table": "0.42.0",
     "@lexical/utils": "0.42.0",
+    "@lexical/yjs": "0.42.0",
     "@shikijs/core": "^3.20.0",
     "@shikijs/engine-javascript": "^3.20.0",
     "@xmldom/xmldom": "^0.8.11",
@@ -144,7 +145,8 @@
     "remark-supersub": "^1.0.0",
     "shiki": "^3.20.0",
     "ts-key-enum": "^3.0.13",
-    "use-merge-value": "^1.2.0"
+    "use-merge-value": "^1.2.0",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "@commitlint/cli": "^19.8.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ export * from './plugins/block';
 export * from './plugins/code';
 export * from './plugins/codeblock';
 export * from './plugins/codemirror-block';
+export * from './plugins/collaboration';
 export * from './plugins/common';
 export * from './plugins/content-blocks';
 export * from './plugins/file';

--- a/src/plugins/collaboration/__tests__/utils.test.ts
+++ b/src/plugins/collaboration/__tests__/utils.test.ts
@@ -3,7 +3,11 @@ import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical';
 import { Doc } from 'yjs';
 
 import Editor from '@/editor-kernel';
+import { CodeblockPlugin } from '@/plugins/codeblock';
 import { CommonPlugin } from '@/plugins/common/plugin';
+import { ImagePlugin } from '@/plugins/image';
+import { ListPlugin } from '@/plugins/list';
+import { TablePlugin } from '@/plugins/table';
 
 import { registerCollaborationBinding } from '../utils';
 
@@ -28,6 +32,162 @@ const emptyEditorState = {
     version: 1,
   },
 };
+
+const headingEditorState = {
+  root: {
+    children: [
+      {
+        children: [
+          {
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'Shared heading',
+            type: 'text',
+            version: 1,
+          },
+        ],
+        direction: null,
+        format: '',
+        indent: 0,
+        tag: 'h2',
+        type: 'heading',
+        version: 1,
+      },
+    ],
+    direction: null,
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+};
+
+const richEditorState = {
+  root: {
+    children: [
+      headingEditorState.root.children[0],
+      {
+        children: [
+          {
+            children: [
+              {
+                detail: 0,
+                format: 0,
+                mode: 'normal',
+                style: '',
+                text: 'Joining clients hydrate from the room snapshot.',
+                type: 'text',
+                version: 1,
+              },
+            ],
+            direction: 'ltr',
+            format: '',
+            indent: 0,
+            type: 'listitem',
+            value: 1,
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        listType: 'bullet',
+        start: 1,
+        tag: 'ul',
+        type: 'list',
+        version: 1,
+      },
+      {
+        children: [
+          {
+            children: [
+              {
+                backgroundColor: null,
+                children: [
+                  {
+                    children: [
+                      {
+                        detail: 0,
+                        format: 0,
+                        mode: 'normal',
+                        style: '',
+                        text: 'Area',
+                        type: 'text',
+                        version: 1,
+                      },
+                    ],
+                    direction: null,
+                    format: '',
+                    indent: 0,
+                    textFormat: 0,
+                    textStyle: '',
+                    type: 'paragraph',
+                    version: 1,
+                  },
+                ],
+                colSpan: 1,
+                direction: 'ltr',
+                format: '',
+                headerState: 3,
+                indent: 0,
+                rowSpan: 1,
+                type: 'tablecell',
+                version: 1,
+              },
+            ],
+            direction: 'ltr',
+            format: '',
+            height: null,
+            indent: 0,
+            type: 'tablerow',
+            version: 1,
+          },
+        ],
+        colWidths: [180],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'table',
+        version: 1,
+      },
+      {
+        altText: 'Generated product board placeholder',
+        height: 160,
+        maxWidth: 640,
+        src: 'https://dummyimage.com/960x320/e2e8f0/334155&text=Workspace+Artifact',
+        status: 'uploaded',
+        type: 'block-image',
+        version: 1,
+        width: 480,
+      },
+      {
+        children: [],
+        code: 'const roomId = `${workspaceId}:${pageId}`;',
+        codeTheme: 'default',
+        direction: null,
+        format: '',
+        indent: 0,
+        language: 'typescript',
+        options: {
+          indentWithTabs: false,
+          lineNumbers: false,
+          tabSize: 2,
+        },
+        type: 'code',
+        version: 1,
+      },
+    ],
+    direction: null,
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+};
+
+const collaborationPlugins = [CommonPlugin, ListPlugin, TablePlugin, ImagePlugin, CodeblockPlugin];
 
 const createNoopAwareness = (): ProviderAwareness => {
   let localState: UserState | null = null;
@@ -116,6 +276,58 @@ describe('registerCollaborationBinding', () => {
 
     const rightJson = rightEditor.getDocument('json') as unknown as typeof emptyEditorState;
     expect(JSON.stringify(rightJson)).toContain('Synced through Yjs');
+
+    leftBinding.cleanup();
+    rightBinding.cleanup();
+  });
+
+  it('bootstraps registered rich element nodes through a shared Y.Doc', async () => {
+    const doc = new Doc();
+    const docMap = new Map([['room-1', doc]]);
+    const leftProvider = createNoopProvider();
+    const rightProvider = createNoopProvider();
+
+    const leftEditor = Editor.createEditor().registerPlugins(collaborationPlugins);
+    const rightEditor = Editor.createEditor().registerPlugins(collaborationPlugins);
+    const leftLexicalEditor = leftEditor.initNodeEditor();
+    const rightLexicalEditor = rightEditor.initNodeEditor();
+
+    if (!leftLexicalEditor || !rightLexicalEditor) {
+      throw new Error('Failed to initialize test Lexical editors');
+    }
+
+    leftEditor.setDocument('json', richEditorState);
+    rightEditor.setDocument('json', emptyEditorState);
+
+    const leftBinding = registerCollaborationBinding({
+      doc,
+      id: 'room-1',
+      lexicalEditor: leftLexicalEditor,
+      provider: leftProvider,
+      shouldBootstrap: true,
+      syncCursorPositionsFn: () => {},
+      yjsDocMap: docMap,
+    });
+    const rightBinding = registerCollaborationBinding({
+      doc,
+      id: 'room-1',
+      lexicalEditor: rightLexicalEditor,
+      provider: rightProvider,
+      syncCursorPositionsFn: () => {},
+      yjsDocMap: docMap,
+    });
+
+    const rightJson = rightEditor.getDocument('json') as unknown as typeof richEditorState;
+
+    expect(rightJson.root.children[0].type).toBe('heading');
+    expect(JSON.stringify(rightJson)).toContain('Shared heading');
+    expect(rightJson.root.children.map((node) => node.type)).toEqual([
+      'heading',
+      'list',
+      'table',
+      'block-image',
+      'code',
+    ]);
 
     leftBinding.cleanup();
     rightBinding.cleanup();

--- a/src/plugins/collaboration/__tests__/utils.test.ts
+++ b/src/plugins/collaboration/__tests__/utils.test.ts
@@ -1,0 +1,123 @@
+import type { Provider, ProviderAwareness, UserState } from '@lexical/yjs';
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical';
+import { Doc } from 'yjs';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common/plugin';
+
+import { registerCollaborationBinding } from '../utils';
+
+const emptyEditorState = {
+  root: {
+    children: [
+      {
+        children: [],
+        direction: null,
+        format: '',
+        indent: 0,
+        textFormat: 0,
+        textStyle: '',
+        type: 'paragraph',
+        version: 1,
+      },
+    ],
+    direction: null,
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+};
+
+const createNoopAwareness = (): ProviderAwareness => {
+  let localState: UserState | null = null;
+
+  return {
+    getLocalState: () => localState,
+    getStates: () => new Map(),
+    off: () => {},
+    on: () => {},
+    setLocalState: (state) => {
+      localState = state;
+    },
+    setLocalStateField: (field, value) => {
+      localState = {
+        ...(localState ?? {
+          anchorPos: null,
+          awarenessData: {},
+          color: '#1677ff',
+          focusPos: null,
+          focusing: true,
+          name: 'Test',
+        }),
+        [field]: value,
+      };
+    },
+  };
+};
+
+const createNoopProvider = (): Provider => ({
+  awareness: createNoopAwareness(),
+  connect: () => {},
+  disconnect: () => {},
+  off: () => {},
+  on: () => {},
+});
+
+describe('registerCollaborationBinding', () => {
+  it('syncs Lexical updates through a shared Y.Doc', async () => {
+    const doc = new Doc();
+    const docMap = new Map([['room-1', doc]]);
+    const leftProvider = createNoopProvider();
+    const rightProvider = createNoopProvider();
+
+    const leftEditor = Editor.createEditor().registerPlugins([CommonPlugin]);
+    const rightEditor = Editor.createEditor().registerPlugins([CommonPlugin]);
+    const leftLexicalEditor = leftEditor.initNodeEditor();
+    const rightLexicalEditor = rightEditor.initNodeEditor();
+
+    if (!leftLexicalEditor || !rightLexicalEditor) {
+      throw new Error('Failed to initialize test Lexical editors');
+    }
+
+    leftEditor.setDocument('json', emptyEditorState);
+    rightEditor.setDocument('json', emptyEditorState);
+
+    const leftBinding = registerCollaborationBinding({
+      doc,
+      id: 'room-1',
+      lexicalEditor: leftLexicalEditor,
+      provider: leftProvider,
+      shouldBootstrap: true,
+      syncCursorPositionsFn: () => {},
+      yjsDocMap: docMap,
+    });
+    const rightBinding = registerCollaborationBinding({
+      doc,
+      id: 'room-1',
+      lexicalEditor: rightLexicalEditor,
+      provider: rightProvider,
+      syncCursorPositionsFn: () => {},
+      yjsDocMap: docMap,
+    });
+
+    leftLexicalEditor.update(
+      () => {
+        const root = $getRoot();
+        const paragraph = $createParagraphNode();
+        paragraph.append($createTextNode('Synced through Yjs'));
+        root.clear();
+        root.append(paragraph);
+      },
+      { discrete: true },
+    );
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    const rightJson = rightEditor.getDocument('json') as unknown as typeof emptyEditorState;
+    expect(JSON.stringify(rightJson)).toContain('Synced through Yjs');
+
+    leftBinding.cleanup();
+    rightBinding.cleanup();
+  });
+});

--- a/src/plugins/collaboration/index.ts
+++ b/src/plugins/collaboration/index.ts
@@ -1,0 +1,2 @@
+export * from './react';
+export type { CollaborationUser } from './utils';

--- a/src/plugins/collaboration/react/ReactCollaborationPlugin.tsx
+++ b/src/plugins/collaboration/react/ReactCollaborationPlugin.tsx
@@ -1,0 +1,145 @@
+'use client';
+
+import type { FC, MutableRefObject } from 'react';
+import { useMemo, useRef } from 'react';
+import { Doc } from 'yjs';
+
+import { useLexicalEditor } from '@/editor-kernel/react';
+
+import {
+  getOrCreateYDoc,
+  initializeCollaborationUser,
+  registerCollaborationBinding,
+} from '../utils';
+import type { ReactCollaborationPluginProps } from './type';
+
+const defaultYjsDocMap = new Map<string, Doc>();
+
+type StatusChangeHandler = ReactCollaborationPluginProps['onStatusChange'];
+type SyncHandler = ReactCollaborationPluginProps['onSync'];
+
+const createProviderStatusHandler = (
+  statusChangeRef: MutableRefObject<StatusChangeHandler | undefined>,
+) => {
+  return function handleProviderStatus({ status }: { status: string }) {
+    statusChangeRef.current?.(status);
+  };
+};
+
+const createProviderSyncHandler = (syncRef: MutableRefObject<SyncHandler | undefined>) => {
+  return function handleProviderSync(isSynced: boolean) {
+    syncRef.current?.(isSynced);
+  };
+};
+
+const createCursorContainer = (rootElement: HTMLElement | null) => {
+  const parentElement = rootElement?.parentElement;
+  if (!rootElement || !parentElement) return null;
+
+  const computedStyle = getComputedStyle(parentElement);
+  if (computedStyle.position === 'static') {
+    parentElement.style.position = 'relative';
+  }
+
+  const container = document.createElement('div');
+  container.dataset.lobeEditorCollaborationCursors = 'true';
+  container.style.inset = '0';
+  container.style.pointerEvents = 'none';
+  container.style.position = 'absolute';
+  container.style.zIndex = '20';
+  parentElement.append(container);
+
+  return container;
+};
+
+export const ReactCollaborationPlugin: FC<ReactCollaborationPluginProps> = ({
+  connect = true,
+  cursorContainer,
+  excludedProperties,
+  id,
+  onStatusChange,
+  onSync,
+  providerFactory,
+  shouldBootstrap,
+  syncCursorPositionsFn,
+  user,
+  yjsDocMap,
+}) => {
+  const statusChangeRef = useRef(onStatusChange);
+  const syncRef = useRef(onSync);
+  statusChangeRef.current = onStatusChange;
+  syncRef.current = onSync;
+
+  const docMap = useMemo(() => yjsDocMap ?? defaultYjsDocMap, [yjsDocMap]);
+
+  useLexicalEditor(
+    (lexicalEditor) => {
+      let teardown: (() => void) | undefined;
+      const timeoutId = setTimeout(() => {
+        const doc = getOrCreateYDoc(id, docMap, () => new Doc());
+        const provider = providerFactory(id, docMap);
+        const effectiveDoc = docMap.get(id) ?? doc;
+        const ownedCursorContainer =
+          cursorContainer ?? createCursorContainer(lexicalEditor.getRootElement());
+
+        initializeCollaborationUser(provider, user);
+
+        const statusHandler = createProviderStatusHandler(statusChangeRef);
+        const syncHandler = createProviderSyncHandler(syncRef);
+
+        provider.on('status', statusHandler);
+        provider.on('sync', syncHandler);
+
+        const { cleanup } = registerCollaborationBinding({
+          cursorContainer: ownedCursorContainer,
+          doc: effectiveDoc,
+          excludedProperties,
+          id,
+          lexicalEditor,
+          provider,
+          shouldBootstrap,
+          syncCursorPositionsFn,
+          yjsDocMap: docMap,
+        });
+
+        if (connect) {
+          void provider.connect();
+        }
+
+        teardown = () => {
+          cleanup();
+          provider.off('status', statusHandler);
+          provider.off('sync', syncHandler);
+          provider.awareness.setLocalState(null);
+          provider.disconnect();
+
+          if (!cursorContainer) {
+            ownedCursorContainer?.remove();
+          }
+        };
+      }, 0);
+
+      return () => {
+        clearTimeout(timeoutId);
+        teardown?.();
+      };
+    },
+    [
+      connect,
+      cursorContainer,
+      docMap,
+      excludedProperties,
+      id,
+      providerFactory,
+      shouldBootstrap,
+      syncCursorPositionsFn,
+      user,
+    ],
+  );
+
+  return null;
+};
+
+ReactCollaborationPlugin.displayName = 'ReactCollaborationPlugin';
+
+export default ReactCollaborationPlugin;

--- a/src/plugins/collaboration/react/index.ts
+++ b/src/plugins/collaboration/react/index.ts
@@ -1,0 +1,6 @@
+export { default as ReactCollaborationPlugin } from './ReactCollaborationPlugin';
+export type {
+  CollaborationProviderFactory,
+  EditorCollaborationConfig,
+  ReactCollaborationPluginProps,
+} from './type';

--- a/src/plugins/collaboration/react/type.ts
+++ b/src/plugins/collaboration/react/type.ts
@@ -1,0 +1,61 @@
+import type { ExcludedProperties, Provider, SyncCursorPositionsFn } from '@lexical/yjs';
+import type { Doc } from 'yjs';
+
+import type { CollaborationUser } from '../utils';
+
+export type CollaborationProviderFactory = (id: string, yjsDocMap: Map<string, Doc>) => Provider;
+
+export interface EditorCollaborationConfig {
+  /**
+   * Whether the provider should connect immediately.
+   * Set this to false when the business shell needs to create the editor before joining the room.
+   *
+   * @default true
+   */
+  connect?: boolean;
+  /**
+   * Optional DOM node used by Lexical/Yjs to render remote cursor overlays.
+   * When omitted, the editor creates and owns a cursor container beside the root element.
+   */
+  cursorContainer?: HTMLElement | null;
+  /**
+   * Lexical node properties excluded from Yjs synchronization.
+   */
+  excludedProperties?: ExcludedProperties;
+  /**
+   * Stable collaboration room id. For workspace pages, this should be derived from
+   * workspaceId + pageId by the business shell.
+   */
+  id: string;
+  /**
+   * Provider connection status callback.
+   */
+  onStatusChange?: (status: string) => void;
+  /**
+   * Provider sync state callback.
+   */
+  onSync?: (isSynced: boolean) => void;
+  /**
+   * Factory that adapts the business collaboration transport to Lexical's Provider contract.
+   */
+  providerFactory: CollaborationProviderFactory;
+  /**
+   * Bootstrap the current Lexical editor state into Yjs only when the Y.Doc root is empty.
+   * Use this for lazy migration from legacy page JSON.
+   *
+   * @default false
+   */
+  shouldBootstrap?: boolean;
+  syncCursorPositionsFn?: SyncCursorPositionsFn;
+  /**
+   * Current user's collaboration identity and awareness metadata.
+   */
+  user: CollaborationUser;
+  /**
+   * Optional externally-owned Y.Doc registry. Supplying this lets the business shell
+   * control document lifetime across page mounts.
+   */
+  yjsDocMap?: Map<string, Doc>;
+}
+
+export type ReactCollaborationPluginProps = EditorCollaborationConfig;

--- a/src/plugins/collaboration/utils.ts
+++ b/src/plugins/collaboration/utils.ts
@@ -1,0 +1,168 @@
+import type { BindingV2, ExcludedProperties, Provider, SyncCursorPositionsFn } from '@lexical/yjs';
+import {
+  createBindingV2__EXPERIMENTAL,
+  initLocalState,
+  syncCursorPositions,
+  syncLexicalUpdateToYjsV2__EXPERIMENTAL,
+  syncYjsChangesToLexicalV2__EXPERIMENTAL,
+  syncYjsStateToLexicalV2__EXPERIMENTAL,
+} from '@lexical/yjs';
+import type { LexicalEditor } from 'lexical';
+import { COLLABORATION_TAG } from 'lexical';
+import type { Doc, Transaction, XmlElement, XmlText, YEvent } from 'yjs';
+
+export interface CollaborationUser {
+  awarenessData?: Record<string, unknown>;
+  color: string;
+  focusing?: boolean;
+  name: string;
+}
+
+export interface CollaborationBindingOptions {
+  cursorContainer?: HTMLElement | null;
+  doc: Doc;
+  excludedProperties?: ExcludedProperties;
+  id: string;
+  lexicalEditor: LexicalEditor;
+  provider: Provider;
+  shouldBootstrap?: boolean;
+  syncCursorPositionsFn?: SyncCursorPositionsFn;
+  yjsDocMap: Map<string, Doc>;
+}
+
+export interface CollaborationBindingHandle {
+  binding: BindingV2;
+  cleanup: () => void;
+}
+
+export const getOrCreateYDoc = (id: string, yjsDocMap: Map<string, Doc>, createDoc: () => Doc) => {
+  const existingDoc = yjsDocMap.get(id);
+  if (existingDoc) return existingDoc;
+
+  const doc = createDoc();
+  yjsDocMap.set(id, doc);
+  return doc;
+};
+
+export const initializeCollaborationUser = (provider: Provider, user: CollaborationUser) => {
+  initLocalState(provider, user.name, user.color, user.focusing ?? true, user.awarenessData ?? {});
+};
+
+const isStaleLexicalNodeError = (error: unknown) =>
+  error instanceof Error &&
+  error.message.includes('Lexical node does not exist in active editor state');
+
+export const registerCollaborationBinding = ({
+  cursorContainer,
+  doc,
+  excludedProperties,
+  id,
+  lexicalEditor,
+  provider,
+  shouldBootstrap = false,
+  syncCursorPositionsFn = syncCursorPositions,
+  yjsDocMap,
+}: CollaborationBindingOptions): CollaborationBindingHandle => {
+  const binding = createBindingV2__EXPERIMENTAL(lexicalEditor, id, doc, yjsDocMap, {
+    excludedProperties,
+  });
+  binding.cursorsContainer = cursorContainer ?? null;
+
+  const rootHasContent = binding.root.length > 0;
+
+  if (rootHasContent) {
+    syncYjsStateToLexicalV2__EXPERIMENTAL(binding, provider);
+  } else if (shouldBootstrap) {
+    const editorState = lexicalEditor.getEditorState();
+    syncLexicalUpdateToYjsV2__EXPERIMENTAL(
+      binding,
+      provider,
+      editorState,
+      editorState,
+      new Map([['root', true]]),
+      new Set(),
+      new Set(),
+    );
+  }
+
+  const yjsObserver = (events: Array<YEvent<XmlElement | XmlText>>, transaction: Transaction) => {
+    if (transaction.origin === binding) return;
+    syncYjsChangesToLexicalV2__EXPERIMENTAL(binding, provider, events, transaction, false);
+  };
+
+  let isCleanedUp = false;
+  let cursorSyncQueued = false;
+  let cursorSyncRetryQueued = false;
+  const syncCursorsSafely = () => {
+    try {
+      syncCursorPositionsFn(binding, provider);
+    } catch (error) {
+      if (!isStaleLexicalNodeError(error)) {
+        throw error;
+      }
+
+      if (cursorSyncRetryQueued) return;
+
+      cursorSyncRetryQueued = true;
+      syncYjsStateToLexicalV2__EXPERIMENTAL(binding, provider);
+      setTimeout(() => {
+        cursorSyncRetryQueued = false;
+        if (isCleanedUp) return;
+
+        try {
+          syncCursorPositionsFn(binding, provider);
+        } catch (retryError) {
+          if (!isStaleLexicalNodeError(retryError)) {
+            throw retryError;
+          }
+        }
+      }, 0);
+    }
+  };
+
+  const scheduleCursorSync = () => {
+    if (cursorSyncQueued) return;
+
+    cursorSyncQueued = true;
+    setTimeout(() => {
+      cursorSyncQueued = false;
+      if (isCleanedUp) return;
+
+      syncCursorsSafely();
+    }, 0);
+  };
+
+  const awarenessObserver = () => {
+    scheduleCursorSync();
+  };
+
+  const unregisterUpdateListener = lexicalEditor.registerUpdateListener(
+    ({ dirtyElements, editorState, normalizedNodes, prevEditorState, tags }) => {
+      syncLexicalUpdateToYjsV2__EXPERIMENTAL(
+        binding,
+        provider,
+        prevEditorState,
+        editorState,
+        dirtyElements,
+        normalizedNodes,
+        tags,
+      );
+      scheduleCursorSync();
+    },
+  );
+
+  binding.root.observeDeep(yjsObserver);
+  provider.awareness.on('update', awarenessObserver);
+
+  return {
+    binding,
+    cleanup: () => {
+      isCleanedUp = true;
+      unregisterUpdateListener();
+      binding.root.unobserveDeep(yjsObserver);
+      provider.awareness.off('update', awarenessObserver);
+      lexicalEditor.update(() => {}, { tag: COLLABORATION_TAG });
+      binding.cursorsContainer = null;
+    },
+  };
+};

--- a/src/plugins/collaboration/utils.ts
+++ b/src/plugins/collaboration/utils.ts
@@ -52,6 +52,10 @@ const isStaleLexicalNodeError = (error: unknown) =>
   error instanceof Error &&
   error.message.includes('Lexical node does not exist in active editor state');
 
+const flushBindingNodeProperties = (lexicalEditor: LexicalEditor) => {
+  lexicalEditor.update(() => {}, { discrete: true });
+};
+
 export const registerCollaborationBinding = ({
   cursorContainer,
   doc,
@@ -66,6 +70,7 @@ export const registerCollaborationBinding = ({
   const binding = createBindingV2__EXPERIMENTAL(lexicalEditor, id, doc, yjsDocMap, {
     excludedProperties,
   });
+  flushBindingNodeProperties(lexicalEditor);
   binding.cursorsContainer = cursorContainer ?? null;
 
   const rootHasContent = binding.root.length > 0;

--- a/src/plugins/image/node/block-image-node.tsx
+++ b/src/plugins/image/node/block-image-node.tsx
@@ -65,6 +65,10 @@ export class BlockImageNode extends BaseImageNode {
     src: string;
     status?: 'uploaded' | 'loading' | 'error';
     width?: 'inherit' | number;
+  } = {
+    altText: '',
+    maxWidth: 4200,
+    src: '',
   }) {
     super(opt.src, opt.altText, opt.maxWidth, opt.width, opt.height, opt.key);
     this.__status = opt.status ?? 'uploaded';

--- a/src/plugins/image/node/image-node.tsx
+++ b/src/plugins/image/node/image-node.tsx
@@ -32,6 +32,10 @@ export class ImageNode extends BaseImageNode {
     src: string;
     status?: 'uploaded' | 'loading' | 'error';
     width?: 'inherit' | number;
+  } = {
+    altText: '',
+    maxWidth: 4200,
+    src: '',
   }) {
     super(opt.src, opt.altText, opt.maxWidth, opt.width, opt.height, opt.key);
     this.__status = opt.status ?? 'uploaded';

--- a/src/plugins/table/utils/index.ts
+++ b/src/plugins/table/utils/index.ts
@@ -1,5 +1,5 @@
 import { $isTableCellNode, $isTableSelection, TableDOMCell, TableSelection } from '@lexical/table';
-import { TableDOMTable } from '@lexical/table/LexicalTableObserver';
+import type { TableDOMTable } from '@lexical/table/LexicalTableObserver';
 import { addClassNamesToElement, removeClassNamesFromElement } from '@lexical/utils';
 import {
   $getNearestNodeFromDOMNode,

--- a/src/react/Editor/Editor.tsx
+++ b/src/react/Editor/Editor.tsx
@@ -4,6 +4,7 @@ import { debounce } from 'es-toolkit';
 import { createElement, memo, useMemo } from 'react';
 
 import { ReactEditor } from '@/editor-kernel/react/react-editor';
+import { ReactCollaborationPlugin } from '@/plugins/collaboration';
 import { ReactEditorContent, ReactPlainText } from '@/plugins/common';
 import ReactMarkdownPlugin from '@/plugins/markdown/react';
 import { ReactMentionPlugin } from '@/plugins/mention';
@@ -18,6 +19,7 @@ const Editor = memo<EditorProps>(
     content,
     style,
     className,
+    collaboration,
     debounceWait = 100,
     editable,
     editor,
@@ -68,9 +70,11 @@ const Editor = memo<EditorProps>(
     const memoPlugins = useMemo(
       () =>
         (
-          [enablePasteMarkdown && autoFormatMarkdown && ReactMarkdownPlugin, ...plugins].filter(
-            Boolean,
-          ) as EditorPlugin[]
+          [
+            collaboration && [ReactCollaborationPlugin, collaboration],
+            enablePasteMarkdown && autoFormatMarkdown && ReactMarkdownPlugin,
+            ...plugins,
+          ].filter(Boolean) as EditorPlugin[]
         ).map((plugin, index) => {
           const withNoProps = typeof plugin === 'function';
           if (withNoProps) return createElement(plugin, { key: index });
@@ -79,7 +83,7 @@ const Editor = memo<EditorProps>(
             ...plugin[1],
           });
         }),
-      [plugins, enablePasteMarkdown, autoFormatMarkdown, ReactMarkdownPlugin],
+      [plugins, collaboration, enablePasteMarkdown, autoFormatMarkdown, ReactMarkdownPlugin],
     );
 
     const memoMention = useMemo(() => {

--- a/src/react/Editor/demos/collaboration.tsx
+++ b/src/react/Editor/demos/collaboration.tsx
@@ -1,0 +1,328 @@
+import type { Provider, ProviderAwareness, UserState } from '@lexical/yjs';
+import type { EditorCollaborationConfig, IEditor } from '@lobehub/editor';
+import { ReactBlockPlugin } from '@lobehub/editor';
+import { Editor, useEditor } from '@lobehub/editor/react';
+import type { CollapseProps } from '@lobehub/ui';
+import { Block, Flexbox, Text } from '@lobehub/ui';
+import { debounce } from 'es-toolkit';
+import { type FC, useCallback, useMemo, useState } from 'react';
+import { Doc, applyUpdate, encodeStateAsUpdate } from 'yjs';
+
+import Container from './Container';
+import content from './disableMakrdownData.json';
+
+class InMemoryCollaborationRoom {
+  private awarenessStates = new Map<number, UserState>();
+  private providers = new Set<InMemoryProvider>();
+
+  addProvider(provider: InMemoryProvider) {
+    const source: InMemoryProvider | undefined = this.providers.values().next().value;
+    this.providers.add(provider);
+
+    if (source && source !== provider) {
+      provider.syncFrom(source.doc);
+    }
+
+    this.emitAwarenessUpdate();
+  }
+
+  broadcastDocUpdate(source: InMemoryProvider, update: Uint8Array) {
+    for (const provider of this.providers) {
+      if (provider !== source) {
+        provider.receiveUpdate(update);
+      }
+    }
+  }
+
+  getAwarenessStates() {
+    return new Map(this.awarenessStates);
+  }
+
+  removeProvider(provider: InMemoryProvider) {
+    this.providers.delete(provider);
+    this.awarenessStates.delete(provider.clientID);
+    this.emitAwarenessUpdate();
+  }
+
+  setAwarenessState(clientID: number, state: UserState | null) {
+    if (state) {
+      this.awarenessStates.set(clientID, state);
+    } else {
+      this.awarenessStates.delete(clientID);
+    }
+
+    this.emitAwarenessUpdate();
+  }
+
+  private emitAwarenessUpdate() {
+    for (const provider of this.providers) {
+      provider.awareness.emitUpdate();
+    }
+  }
+}
+
+class InMemoryAwareness implements ProviderAwareness {
+  private localState: UserState | null = null;
+  private updateListeners = new Set<() => void>();
+
+  constructor(
+    private readonly room: InMemoryCollaborationRoom,
+    private readonly clientID: number,
+  ) {}
+
+  emitUpdate() {
+    for (const listener of this.updateListeners) {
+      listener();
+    }
+  }
+
+  getLocalState = () => this.localState;
+
+  getStates = () => this.room.getAwarenessStates();
+
+  off = (_type: 'update', callback: () => void) => {
+    this.updateListeners.delete(callback);
+  };
+
+  on = (_type: 'update', callback: () => void) => {
+    this.updateListeners.add(callback);
+  };
+
+  setLocalState = (state: UserState | null) => {
+    this.localState = state;
+    this.room.setAwarenessState(this.clientID, state);
+  };
+
+  setLocalStateField = (field: string, value: unknown) => {
+    this.setLocalState({
+      ...(this.localState ?? {
+        anchorPos: null,
+        awarenessData: {},
+        color: '#1677ff',
+        focusPos: null,
+        focusing: true,
+        name: 'Local',
+      }),
+      [field]: value,
+    });
+  };
+}
+
+class InMemoryProvider implements Provider {
+  readonly awareness: InMemoryAwareness;
+  readonly clientID: number;
+  private connected = false;
+  private readonly reloadListeners = new Set<(_doc: Doc) => void>();
+  private readonly statusListeners = new Set<(_event: { status: string }) => void>();
+  private readonly syncListeners = new Set<(_isSynced: boolean) => void>();
+  private readonly updateListeners = new Set<(_event: unknown) => void>();
+
+  constructor(
+    private readonly room: InMemoryCollaborationRoom,
+    readonly doc: Doc,
+  ) {
+    this.clientID = doc.clientID;
+    this.awareness = new InMemoryAwareness(room, this.clientID);
+  }
+
+  connect() {
+    if (this.connected) return;
+
+    this.connected = true;
+    this.doc.on('update', this.handleDocUpdate);
+    this.room.addProvider(this);
+    this.emitStatus('connected');
+    this.emitSync(true);
+  }
+
+  disconnect() {
+    if (!this.connected) return;
+
+    this.connected = false;
+    this.room.removeProvider(this);
+    this.doc.off('update', this.handleDocUpdate);
+    this.emitStatus('disconnected');
+  }
+
+  off(type: ProviderEventType, callback: ProviderListener) {
+    if (type === 'sync') {
+      this.syncListeners.delete(callback as (isSynced: boolean) => void);
+      return;
+    }
+
+    if (type === 'status') {
+      this.statusListeners.delete(callback as (event: { status: string }) => void);
+      return;
+    }
+
+    if (type === 'reload') {
+      this.reloadListeners.delete(callback as (doc: Doc) => void);
+      return;
+    }
+
+    this.updateListeners.delete(callback as (event: unknown) => void);
+  }
+
+  on(type: ProviderEventType, callback: ProviderListener) {
+    if (type === 'sync') {
+      this.syncListeners.add(callback as (isSynced: boolean) => void);
+      return;
+    }
+
+    if (type === 'status') {
+      this.statusListeners.add(callback as (event: { status: string }) => void);
+      return;
+    }
+
+    if (type === 'reload') {
+      this.reloadListeners.add(callback as (doc: Doc) => void);
+      return;
+    }
+
+    this.updateListeners.add(callback as (event: unknown) => void);
+  }
+
+  receiveUpdate(update: Uint8Array) {
+    applyUpdate(this.doc, update, this.room);
+  }
+
+  syncFrom(sourceDoc: Doc) {
+    applyUpdate(this.doc, encodeStateAsUpdate(sourceDoc), this.room);
+  }
+
+  private emitStatus(status: string) {
+    for (const listener of this.statusListeners) {
+      listener({ status });
+    }
+  }
+
+  private emitSync(isSynced: boolean) {
+    for (const listener of this.syncListeners) {
+      listener(isSynced);
+    }
+  }
+
+  private readonly handleDocUpdate = (update: Uint8Array, origin: unknown) => {
+    if (!this.connected || origin === this.room) return;
+
+    for (const listener of this.updateListeners) {
+      listener(update);
+    }
+
+    this.room.broadcastDocUpdate(this, update);
+  };
+}
+
+const roomId = 'lobe-editor-collaboration-demo';
+type ProviderEventType = 'reload' | 'status' | 'sync' | 'update';
+type ProviderListener =
+  | ((_doc: Doc) => void)
+  | ((_event: unknown) => void)
+  | ((_event: { status: string }) => void)
+  | ((_isSynced: boolean) => void);
+
+const Demo: FC<Pick<CollapseProps, 'collapsible' | 'defaultActiveKey'>> = (props) => {
+  const leftEditor = useEditor();
+  const rightEditor = useEditor();
+  const leftYjsDocMap = useMemo(() => new Map([[roomId, new Doc()]]), []);
+  const rightYjsDocMap = useMemo(() => new Map([[roomId, new Doc()]]), []);
+  const room = useMemo(() => new InMemoryCollaborationRoom(), []);
+  const [json, setJson] = useState('');
+  const [markdown, setMarkdown] = useState('');
+
+  const providerFactory = useCallback(
+    (id: string, yjsDocMap: Map<string, Doc>) => {
+      const doc = yjsDocMap.get(id);
+
+      if (!doc) {
+        throw new Error(`Missing Y.Doc for collaboration room: ${id}`);
+      }
+
+      return new InMemoryProvider(room, doc);
+    },
+    [room],
+  );
+
+  const createCollaborationConfig = useCallback(
+    (
+      name: string,
+      color: string,
+      yjsDocMap: Map<string, Doc>,
+      shouldBootstrap = false,
+    ): EditorCollaborationConfig => ({
+      id: roomId,
+      providerFactory,
+      shouldBootstrap,
+      user: {
+        color,
+        name,
+      },
+      yjsDocMap,
+    }),
+    [providerFactory],
+  );
+
+  const leftCollaboration = useMemo(
+    () => createCollaborationConfig('Editor A', '#1677ff', leftYjsDocMap, true),
+    [createCollaborationConfig, leftYjsDocMap],
+  );
+
+  const rightCollaboration = useMemo(
+    () => createCollaborationConfig('Editor B', '#00a870', rightYjsDocMap),
+    [createCollaborationConfig, rightYjsDocMap],
+  );
+
+  const handleChange = useMemo(
+    () =>
+      debounce((editor: IEditor) => {
+        const markdownContent = editor.getDocument('markdown') as unknown as string;
+        const jsonContent = editor.getDocument('json') as unknown as Record<string, unknown>;
+        setMarkdown(markdownContent || '');
+        setJson(JSON.stringify(jsonContent || {}, null, 2));
+      }, 300),
+    [],
+  );
+
+  return (
+    <Container json={json} markdown={markdown} {...props}>
+      <Flexbox gap={12} style={{ padding: 16 }}>
+        <Text type={'secondary'}>
+          Each editor owns an independent Y.Doc. The in-memory provider relays document updates and
+          awareness states so remote selections render as collaborator cursors.
+        </Text>
+        <Flexbox gap={12} horizontal>
+          <Block style={{ flex: 1, minWidth: 0 }} variant={'outlined'}>
+            <Flexbox gap={8} style={{ padding: 12 }}>
+              <Text strong>Editor A</Text>
+              <Editor
+                collaboration={leftCollaboration}
+                content={content}
+                editor={leftEditor}
+                onInit={handleChange}
+                onTextChange={handleChange}
+                placeholder={'Type in editor A...'}
+                plugins={[ReactBlockPlugin]}
+              />
+            </Flexbox>
+          </Block>
+          <Block style={{ flex: 1, minWidth: 0 }} variant={'outlined'}>
+            <Flexbox gap={8} style={{ padding: 12 }}>
+              <Text strong>Editor B</Text>
+              <Editor
+                collaboration={rightCollaboration}
+                content={content}
+                editor={rightEditor}
+                onInit={handleChange}
+                onTextChange={handleChange}
+                placeholder={'Type in editor B...'}
+                plugins={[ReactBlockPlugin]}
+              />
+            </Flexbox>
+          </Block>
+        </Flexbox>
+      </Flexbox>
+    </Container>
+  );
+};
+
+export default Demo;

--- a/src/react/Editor/index.md
+++ b/src/react/Editor/index.md
@@ -38,6 +38,12 @@ When `editable` is `false`, the floating block menu (add-block button and drag h
 
 <code src="./demos/editable.tsx" nopadding iframe></code>
 
+## Collaboration
+
+Two editor instances can share the same Yjs document through the `collaboration` prop.
+
+<code src="./demos/collaboration.tsx" nopadding iframe></code>
+
 ## Paste as Plain Text
 
 Force all pasted content to be inserted as plain text, stripping any rich text formatting (bold, italic, links, etc).
@@ -54,6 +60,7 @@ Force all pasted content to be inserted as plain text, stripping any rich text f
 | autoFormatMarkdown                | Automatically convert pasted markdown once the detection threshold is reached | `boolean`                                                                               | `true`   |
 | children                          | Additional content or components                                              | `ReactNode`                                                                             | -        |
 | className                         | Custom CSS class                                                              | `string`                                                                                | -        |
+| collaboration                     | Yjs collaboration configuration                                               | `false \| EditorCollaborationConfig`                                                    | -        |
 | content                           | Initial editor content                                                        | `ReactEditorContentProps['content']`                                                    | -        |
 | editor                            | Editor instance to use                                                        | `IEditor`                                                                               | -        |
 | enablePasteMarkdown               | Enable automatic markdown conversion for pasted content                       | `boolean`                                                                               | `true`   |

--- a/src/react/Editor/type.ts
+++ b/src/react/Editor/type.ts
@@ -1,5 +1,6 @@
 import type { CSSProperties, FC, ReactNode } from 'react';
 
+import type { EditorCollaborationConfig } from '@/plugins/collaboration';
 import type { ReactEditorContentProps, ReactPlainTextProps } from '@/plugins/common/react';
 import type { ReactMentionPluginProps } from '@/plugins/mention/react';
 import type { ReactSlashOptionProps } from '@/plugins/slash/react';
@@ -21,6 +22,7 @@ export interface EditorProps
   autoFormatMarkdown?: boolean;
   children?: ReactNode;
   className?: string;
+  collaboration?: false | EditorCollaborationConfig;
   /**
    * Debounce wait time in milliseconds for onChange and onTextChange callbacks
    * @default 100

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -20,3 +20,7 @@ export { type EditorState, useEditorState } from './hooks/useEditorState';
 export { default as SendButton, type SendButtonProps } from './SendButton';
 export { default as SlashMenu, type SlashMenuProps } from './SlashMenu';
 export { ANCHOR_PADDING_CSS_VAR, DEFAULT_BLOCK_ANCHOR_PADDING } from '@/plugins/block/react/style';
+export type {
+  CollaborationProviderFactory,
+  EditorCollaborationConfig,
+} from '@/plugins/collaboration';


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

This PR adds the editor-level collaboration contract for Lexical/Yjs based collaboration.

- Adds the `collaboration` prop integration to `Editor` with a stable `EditorCollaborationConfig` type.
- Adds `ReactCollaborationPlugin`, Y.Doc binding helpers, user awareness initialization, cursor container ownership, bootstrap/hydrate behavior, and stale cursor sync recovery.
- Exports collaboration types from both package root and `@lobehub/editor/react` for business integration.
- Adds a behavior test for synchronizing Lexical updates through a shared Y.Doc.
- Adds a standalone Hono + Vite React business demo that covers workspace page rooms, first-open bootstrap, snapshot hydrate, re-enter, reconnect, read-only observer, complex nodes, and room reset.

#### 📝 Additional Information

Validation performed:

- `pnpm type-check`
- `pnpm exec vitest run --silent='passed-only' src/plugins/collaboration/__tests__/utils.test.ts`
- `pnpm build`
- `cd examples/collaboration-business-demo && pnpm type-check`
- `cd examples/collaboration-business-demo && pnpm build`

No related issue was found for the collaboration API work.
