### PR TITLE
✨ feat(slash): support sectioned menu options

### DIFF
--- a/src/plugins/slash/index.ts
+++ b/src/plugins/slash/index.ts
@@ -1,4 +1,16 @@
 export * from './plugin';
 export * from './react';
-export type { ISlashMenuOption, ISlashService, SlashOptions } from './service/i-slash-service';
-export type { ISlashOption } from './service/i-slash-service';
+export type {
+  ISlashDividerOption,
+  ISlashMenuOption,
+  ISlashOption,
+  ISlashSectionOption,
+  ISlashService,
+  SlashOptions,
+} from './service/i-slash-service';
+export {
+  flattenSlashOptions,
+  isSlashDividerOption,
+  isSlashMenuOption,
+  isSlashSectionOption,
+} from './service/i-slash-service';

--- a/src/plugins/slash/react/ReactSlashPlugin.tsx
+++ b/src/plugins/slash/react/ReactSlashPlugin.tsx
@@ -29,6 +29,7 @@ import {
   type ISlashOption,
   ISlashService,
   type SlashOptions,
+  flattenSlashOptions,
 } from '../service/i-slash-service';
 import { $splitNodeContainingQuery } from '../utils/utils';
 import SlashMenu from './components/SlashMenu';
@@ -74,6 +75,16 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
     setActiveKey(key);
   }, []);
 
+  const setInitialActiveKey = useCallback(
+    (items: ISlashOption[]) => {
+      if (!activeKey) {
+        const firstOption = flattenSlashOptions(items)[0];
+        setActiveKey(firstOption?.key ? String(firstOption.key) : null);
+      }
+    },
+    [activeKey],
+  );
+
   useLayoutEffect(() => {
     const options =
       Children.map(children, (child) => {
@@ -94,10 +105,7 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
         cancelRef.current.cancel();
         if (Array.isArray(ctx.items)) {
           setOptions(ctx.items);
-          if (!activeKey) {
-            // @ts-ignore
-            setActiveKey(ctx.items?.[0]?.key);
-          }
+          setInitialActiveKey(ctx.items);
         } else {
           setLoading(true);
           const pr = setCancelablePromise((resolve, reject) => {
@@ -110,10 +118,7 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
           pr.promise.then((items) => {
             const typedItems = items as ISlashOption[];
             setOptions(typedItems);
-            if (!activeKey) {
-              // @ts-ignore
-              setActiveKey(typedItems?.[0]?.key);
-            }
+            setInitialActiveKey(typedItems);
           });
           cancelRef.current.cancel = () => {
             pr.cancel();
@@ -125,7 +130,7 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
         setIsOpen(true);
       },
     });
-  }, [activeKey, editor, close]);
+  }, [editor, close, setInitialActiveKey]);
 
   useLayoutEffect(() => {
     const slash = editor.requireService(ISlashService);
@@ -143,11 +148,6 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
 
   const handleMenuSelect = useCallback(
     (option: ISlashMenuOption) => {
-      // ISlashMenuOption should not have divider type, but adding check for safety
-      if ('type' in option && (option as any).type === 'divider') {
-        return;
-      }
-
       const lexicalEditor = editor.getLexicalEditor();
       if (lexicalEditor && resolution) {
         lexicalEditor.update(() => {
@@ -173,10 +173,7 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
   );
 
   useLexicalEditor(() => {
-    const pureOptions = options.filter(
-      (item): item is ISlashMenuOption =>
-        !('type' in item && item.type === 'divider') && 'key' in item && Boolean(item.key),
-    );
+    const pureOptions = flattenSlashOptions(options).filter((item) => Boolean(item.key));
     return mergeRegister(
       editor.registerHighCommand<KeyboardEvent>(
         KEY_ARROW_DOWN_COMMAND,
@@ -235,9 +232,7 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
           if (options === null || activeKey === null) {
             return false;
           }
-          const selectedOption = options.find(
-            (opt): opt is ISlashMenuOption => 'key' in opt && opt.key === activeKey,
-          );
+          const selectedOption = flattenSlashOptions(options).find((opt) => opt.key === activeKey);
           if (!selectedOption) {
             return false;
           }
@@ -258,8 +253,8 @@ const ReactSlashPlugin: FC<ReactSlashPluginProps> = ({
 
             // Only select option if we have valid options and activeKey
             if (options !== null && activeKey !== null) {
-              const selectedOption = options.find(
-                (opt): opt is ISlashMenuOption => 'key' in opt && opt.key === activeKey,
+              const selectedOption = flattenSlashOptions(options).find(
+                (opt) => opt.key === activeKey,
               );
               if (selectedOption) {
                 handleMenuSelect(selectedOption);

--- a/src/plugins/slash/react/components/DefaultSlashMenu.tsx
+++ b/src/plugins/slash/react/components/DefaultSlashMenu.tsx
@@ -9,15 +9,18 @@ import {
   size,
   useFloating,
 } from '@floating-ui/react';
-import { Icon, menuSharedStyles } from '@lobehub/ui';
+import { Icon, LOBE_THEME_APP_ID, menuSharedStyles } from '@lobehub/ui';
 import { createStaticStyles } from 'antd-style';
 import { type FC, type ReactNode, useEffect, useLayoutEffect, useMemo, useRef } from 'react';
 import { createPortal } from 'react-dom';
 
-import { ISlashMenuOption } from '../../service/i-slash-service';
+import {
+  type ISlashMenuOption,
+  flattenSlashOptions,
+  isSlashDividerOption,
+  isSlashSectionOption,
+} from '../../service/i-slash-service';
 import type { SlashMenuProps } from '../type';
-
-const LOBE_THEME_APP_ID = 'lobe-ui-theme-app';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   popup: css`
@@ -43,12 +46,95 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   root: css`
     z-index: 1100;
   `,
+  section: css`
+    margin-block-start: 4px;
+  `,
+  sectionFirst: css`
+    margin-block-start: 0;
+  `,
+  sectionLabel: css`
+    padding-block: 12px 6px;
+    padding-inline: 8px;
+
+    font-size: 12px;
+    line-height: 1;
+    color: ${cssVar.colorTextDescription};
+
+    &:first-child {
+      padding-block-start: 6px;
+    }
+  `,
+  text: css`
+    display: flex;
+    flex: 1 1 auto;
+    flex-wrap: wrap;
+    gap: 2px 8px;
+    align-items: baseline;
+
+    min-width: 0;
+  `,
+  textDescription: css`
+    overflow: hidden;
+    flex: 0 1 auto;
+
+    min-width: 0;
+
+    color: ${cssVar.colorTextDescription};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
+  textLabel: css`
+    overflow: hidden;
+    flex: 0 1 auto;
+
+    max-width: min(42ch, 55%);
+
+    font-weight: 500;
+    color: ${cssVar.colorText};
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  `,
 }));
 
-const isDividerOption = (option: SlashMenuProps['options'][number]): boolean =>
-  'type' in option && option.type === 'divider';
-
 type DefaultSlashMenuProps = Omit<SlashMenuProps, 'customRender' | 'onActiveKeyChange' | 'editor'>;
+
+const renderMenuItem = (
+  item: ISlashMenuOption,
+  activeKey: string | null,
+  onSelect: (option: ISlashMenuOption) => void,
+): ReactNode => {
+  const isHighlighted = item.key === activeKey;
+  const isDisabled = Boolean(item.disabled);
+  const description = item.metadata?.description as ReactNode | undefined;
+
+  return (
+    <div
+      aria-disabled={isDisabled || undefined}
+      className={menuSharedStyles.item}
+      data-disabled={isDisabled ? '' : undefined}
+      data-highlighted={isHighlighted ? '' : undefined}
+      key={String(item.key)}
+      onClick={() => {
+        if (isDisabled) return;
+        onSelect(item);
+      }}
+      // Prevent the editor from losing focus when the popup is clicked.
+      onMouseDown={(event) => event.preventDefault()}
+      role={'menuitem'}
+    >
+      {item.icon ? (
+        <span className={menuSharedStyles.icon}>
+          <Icon icon={item.icon} />
+        </span>
+      ) : null}
+      <span className={styles.text}>
+        <span className={styles.textLabel}>{item.label}</span>
+        {description ? <span className={styles.textDescription}>{description}</span> : null}
+      </span>
+      {item.extra ? <span className={menuSharedStyles.extra}>{item.extra}</span> : null}
+    </div>
+  );
+};
 
 const renderItems = (
   options: SlashMenuProps['options'],
@@ -58,36 +144,21 @@ const renderItems = (
 ): ReactNode => {
   if (loading) return <div className={menuSharedStyles.empty}>Loading...</div>;
   return options.map((opt, index) => {
-    if (isDividerOption(opt)) {
+    if (isSlashDividerOption(opt)) {
       return <div className={menuSharedStyles.separator} key={`__divider_${index}`} />;
     }
-    const item = opt as ISlashMenuOption;
-    const isHighlighted = item.key === activeKey;
-    const isDisabled = Boolean(item.disabled);
-    return (
-      <div
-        aria-disabled={isDisabled || undefined}
-        className={menuSharedStyles.item}
-        data-disabled={isDisabled ? '' : undefined}
-        data-highlighted={isHighlighted ? '' : undefined}
-        key={String(item.key)}
-        onClick={() => {
-          if (isDisabled) return;
-          onSelect(item);
-        }}
-        // Prevent the editor from losing focus when the popup is clicked.
-        onMouseDown={(event) => event.preventDefault()}
-        role={'menuitem'}
-      >
-        {item.icon ? (
-          <span className={menuSharedStyles.icon}>
-            <Icon icon={item.icon} />
-          </span>
-        ) : null}
-        <span className={menuSharedStyles.label}>{item.label}</span>
-        {item.extra ? <span className={menuSharedStyles.extra}>{item.extra}</span> : null}
-      </div>
-    );
+    if (isSlashSectionOption(opt)) {
+      return (
+        <div
+          className={`${styles.section} ${index === 0 ? styles.sectionFirst : ''}`}
+          key={String(opt.key ?? `__section_${index}`)}
+        >
+          <div className={styles.sectionLabel}>{opt.label}</div>
+          {opt.items.map((item) => renderMenuItem(item, activeKey, onSelect))}
+        </div>
+      );
+    }
+    return renderMenuItem(opt, activeKey, onSelect);
   });
 };
 
@@ -235,7 +306,7 @@ const DefaultSlashMenu: FC<DefaultSlashMenuProps> = ({
   placement,
   position,
 }) => {
-  const hasVisibleItems = options?.some((item) => !isDividerOption(item));
+  const hasVisibleItems = flattenSlashOptions(options).length > 0;
   if (!open || !hasVisibleItems) return null;
 
   const anchor = getPopupContainer?.() ?? null;

--- a/src/plugins/slash/service/i-slash-service.ts
+++ b/src/plugins/slash/service/i-slash-service.ts
@@ -2,6 +2,7 @@
 /* eslint-disable @typescript-eslint/no-redeclare */
 import { DropdownMenuItemType } from '@lobehub/ui';
 import Fuse, { type IFuseOptions } from 'fuse.js';
+import type { ReactNode } from 'react';
 
 import { genServiceId } from '@/editor-kernel';
 import type { IEditor, IEditorKernel, IServiceID } from '@/types';
@@ -18,7 +19,30 @@ export interface ISlashMenuOption extends DropdownMenuItemType {
   onSelect?: (editor: IEditor, matchingString: string) => void;
 }
 
-export type ISlashOption = ISlashMenuOption | ISlashDividerOption;
+export interface ISlashSectionOption {
+  items: ISlashMenuOption[];
+  key?: string;
+  label: ReactNode;
+  type: 'section';
+}
+
+export type ISlashOption = ISlashMenuOption | ISlashDividerOption | ISlashSectionOption;
+
+export const isSlashDividerOption = (option: ISlashOption): option is ISlashDividerOption =>
+  'type' in option && option.type === 'divider';
+
+export const isSlashSectionOption = (option: ISlashOption): option is ISlashSectionOption =>
+  'type' in option && option.type === 'section';
+
+export const isSlashMenuOption = (option: ISlashOption): option is ISlashMenuOption =>
+  !isSlashDividerOption(option) && !isSlashSectionOption(option);
+
+export const flattenSlashOptions = (options: ISlashOption[]): ISlashMenuOption[] =>
+  options.flatMap((option) => {
+    if (isSlashDividerOption(option)) return [];
+    if (isSlashSectionOption(option)) return option.items;
+    return [option];
+  });
 
 export interface SlashOptions {
   allowWhitespace?: boolean;
@@ -93,10 +117,7 @@ export class SlashService implements ISlashService {
     this.logger.debug(`⚡ Slash trigger: ${options.trigger}`);
 
     if (Array.isArray(options.items)) {
-      // Filter out divider items for search functionality
-      const searchableItems = options.items.filter(
-        (item): item is ISlashMenuOption => !('type' in item) || item.type !== 'divider',
-      );
+      const searchableItems = flattenSlashOptions(options.items);
 
       // Use fuseOptions if provided, otherwise fallback to searchKeys or default
       const fuseConfig: IFuseOptions<ISlashMenuOption> = options.fuseOptions || {

--- a/src/react/ChatInput/demos/SectionedMenu.tsx
+++ b/src/react/ChatInput/demos/SectionedMenu.tsx
@@ -1,0 +1,210 @@
+import type { IEditor, ISlashMenuOption, SlashOptions } from '@lobehub/editor';
+import {
+  INSERT_HEADING_COMMAND,
+  INSERT_HORIZONTAL_RULE_COMMAND,
+  INSERT_MENTION_COMMAND,
+  INSERT_TABLE_COMMAND,
+} from '@lobehub/editor';
+import { ChatInput, Editor, useEditor, useEditorState } from '@lobehub/editor/react';
+import { Avatar, Text } from '@lobehub/ui';
+import {
+  BrainCircuitIcon,
+  FileTextIcon,
+  GoalIcon,
+  Heading1Icon,
+  MinusIcon,
+  PaperclipIcon,
+  Table2Icon,
+  WrenchIcon,
+} from 'lucide-react';
+import { useMemo, useRef } from 'react';
+
+import ActionToolbar from './ActionToolbar';
+import Container from './Container';
+import { chatMessages, content } from './data';
+
+const writeMentionMarkdown = (mention: { label: unknown; metadata?: Record<string, unknown> }) =>
+  `\n<mention>${String(mention.label)}[${String(mention.metadata?.id ?? mention.label)}]</mention>\n`;
+
+const insertMention = (editor: IEditor, option: ISlashMenuOption) => {
+  editor.dispatchCommand(INSERT_MENTION_COMMAND, {
+    label: String(option.label ?? option.key),
+    metadata: { id: String(option.key ?? option.label) },
+  });
+};
+
+export default () => {
+  const editor = useEditor();
+  const editorState = useEditorState(editor);
+  const slashMenuRef = useRef<HTMLDivElement>(null);
+
+  const mentionItems: SlashOptions['items'] = useMemo(
+    () => [
+      {
+        items: [
+          {
+            icon: <Avatar avatar={'💻'} size={24} />,
+            key: 'agent-frontend',
+            label: '前端研发专家',
+            metadata: {
+              description: 'Review React, TypeScript, and UI implementation details',
+              id: 'agent-frontend',
+            },
+          },
+          {
+            icon: <Avatar avatar={'📖'} size={24} />,
+            key: 'agent-writing',
+            label: '学术写作增强专家',
+            metadata: {
+              description: 'Improve academic structure, tone, and references',
+              id: 'agent-writing',
+            },
+          },
+        ],
+        key: 'mention-section-agents',
+        label: 'Agents',
+        type: 'section',
+      },
+      {
+        items: [
+          {
+            icon: WrenchIcon,
+            key: 'tool-browser',
+            label: '浏览器',
+            metadata: {
+              description: 'Control the in-app browser with Codex',
+              id: 'tool-browser',
+            },
+          },
+          {
+            icon: FileTextIcon,
+            key: 'tool-pdf',
+            label: 'PDF',
+            metadata: {
+              description: 'Read, create, and verify PDF files',
+              id: 'tool-pdf',
+            },
+          },
+        ],
+        key: 'mention-section-tools',
+        label: 'Tools',
+        type: 'section',
+      },
+    ],
+    [],
+  );
+
+  const slashItems: SlashOptions['items'] = useMemo(
+    () => [
+      {
+        items: [
+          {
+            icon: PaperclipIcon,
+            key: 'files',
+            label: 'Files and folders',
+            metadata: { description: 'Attach local files or folders to the conversation' },
+          },
+          {
+            icon: GoalIcon,
+            key: 'goal',
+            label: 'Goal',
+            metadata: { description: 'Set a persistent objective for Codex to pursue' },
+          },
+          {
+            icon: BrainCircuitIcon,
+            key: 'reasoning',
+            label: 'Reasoning',
+            metadata: { description: 'Use high-effort reasoning for complex work' },
+          },
+        ],
+        key: 'slash-section-add',
+        label: 'Add',
+        type: 'section',
+      },
+      {
+        items: [
+          {
+            icon: Heading1Icon,
+            key: 'heading',
+            label: 'Heading',
+            metadata: { description: 'Insert a heading block' },
+            onSelect: (editor) => {
+              editor.dispatchCommand(INSERT_HEADING_COMMAND, { tag: 'h1' });
+            },
+          },
+          {
+            icon: Table2Icon,
+            key: 'table',
+            label: 'Table',
+            metadata: { description: 'Insert a 3 by 3 table' },
+            onSelect: (editor) => {
+              editor.dispatchCommand(INSERT_TABLE_COMMAND, { columns: '3', rows: '3' });
+            },
+          },
+          {
+            extra: (
+              <Text code fontSize={12} type={'secondary'}>
+                hr
+              </Text>
+            ),
+            icon: MinusIcon,
+            key: 'hr',
+            label: 'Horizontal rule',
+            metadata: { description: 'Insert a visual divider' },
+            onSelect: (editor) => {
+              editor.dispatchCommand(INSERT_HORIZONTAL_RULE_COMMAND, {});
+            },
+          },
+        ],
+        key: 'slash-section-format',
+        label: 'Format',
+        type: 'section',
+      },
+    ],
+    [],
+  );
+
+  const handleSend = () => {
+    editor?.cleanDocument();
+    editor?.focus();
+  };
+
+  return (
+    <Container messages={chatMessages}>
+      <ChatInput
+        defaultHeight={96}
+        footer={
+          <ActionToolbar
+            onSend={handleSend}
+            sendDisabled={!editor || editorState.isEmpty}
+            setShowTypobar={() => {}}
+          />
+        }
+        maxHeight={320}
+        minHeight={64}
+        slashMenuRef={slashMenuRef}
+      >
+        <Editor
+          autoFocus
+          content={content}
+          editor={editor}
+          getPopupContainer={() => slashMenuRef.current}
+          mentionOption={{
+            items: mentionItems,
+            markdownWriter: writeMentionMarkdown,
+            onSelect: insertMention,
+            searchKeys: ['label', 'metadata.description'],
+          }}
+          placeholder={'Type @ or / to open sectioned menus'}
+          slashOption={{
+            fuseOptions: {
+              keys: ['label', 'metadata.description'],
+            },
+            items: slashItems,
+          }}
+          variant={'chat'}
+        />
+      </ChatInput>
+    </Container>
+  );
+};

--- a/src/react/ChatInput/index.md
+++ b/src/react/ChatInput/index.md
@@ -17,6 +17,10 @@ ChatInput is a versatile container component designed for chat input interfaces.
 
 <code src="./demos/index.tsx" iframe nopadding></code>
 
+## Sectioned Menus
+
+<code src="./demos/SectionedMenu.tsx" iframe nopadding></code>
+
 ## APIs
 
 ### ChatInput


### PR DESCRIPTION
#### 💻 Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [x] 📝 docs

#### 🔀 Description of Change

This PR adds sectioned slash menu support on top of the latest `master` branch.

- Add `ISlashSectionOption` and slash option helpers for section detection and flattening.
- Make static Fuse indexing, async menu initial selection, keyboard navigation, Tab/Enter selection, and visibility checks section-aware.
- Render section headers in the default slash menu.
- Render item descriptions from `metadata.description` with a compact inline layout.
- Add a ChatInput demo for sectioned `@` mention and `/` slash menus.

#### 📝 Additional Information

This branch was created directly from the latest `origin/master` and excludes the already-merged full-width slash menu refactor.

Validation completed locally:

- `./node_modules/.bin/prettier --check src/plugins/slash/service/i-slash-service.ts src/plugins/slash/react/ReactSlashPlugin.tsx src/plugins/slash/react/components/DefaultSlashMenu.tsx src/plugins/slash/index.ts src/react/ChatInput/demos/SectionedMenu.tsx src/react/ChatInput/index.md`
- `./node_modules/.bin/eslint src/plugins/slash/service/i-slash-service.ts src/plugins/slash/react/ReactSlashPlugin.tsx src/plugins/slash/react/components/DefaultSlashMenu.tsx src/plugins/slash/index.ts src/react/ChatInput/demos/SectionedMenu.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check origin/master..HEAD`
