### PR TITLE
💄 style(slash): keep menu descriptions inline

### DIFF
--- a/src/plugins/slash/react/components/DefaultSlashMenu.tsx
+++ b/src/plugins/slash/react/components/DefaultSlashMenu.tsx
@@ -65,17 +65,19 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     }
   `,
   text: css`
+    overflow: hidden;
     display: flex;
     flex: 1 1 auto;
-    flex-wrap: wrap;
-    gap: 2px 8px;
+    gap: 8px;
     align-items: baseline;
 
     min-width: 0;
+
+    white-space: nowrap;
   `,
   textDescription: css`
     overflow: hidden;
-    flex: 0 1 auto;
+    flex: 1 1 auto;
 
     min-width: 0;
 


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

Keep slash menu item descriptions on the same line as the title.

- Disable wrapping in the default slash menu item text container.
- Let the description take remaining inline space and truncate with ellipsis.
- Preserve the compact title + description layout introduced by the sectioned menu work.

#### 📝 Additional Information

Validation completed locally:

- `./node_modules/.bin/prettier --check src/plugins/slash/react/components/DefaultSlashMenu.tsx`
- `./node_modules/.bin/eslint src/plugins/slash/react/components/DefaultSlashMenu.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`
- Commit hook also passed `type-check`, `lint:circular`, and lint-staged tasks.
