### PR TITLE
💄 style(slash): preserve full menu titles

### DIFF
--- a/src/plugins/slash/react/components/DefaultSlashMenu.tsx
+++ b/src/plugins/slash/react/components/DefaultSlashMenu.tsx
@@ -86,14 +86,9 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
     white-space: nowrap;
   `,
   textLabel: css`
-    overflow: hidden;
-    flex: 0 1 auto;
-
-    max-width: min(42ch, 55%);
-
+    flex: 0 0 auto;
     font-weight: 500;
     color: ${cssVar.colorText};
-    text-overflow: ellipsis;
     white-space: nowrap;
   `,
 }));


### PR DESCRIPTION
#### 💻 Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [x] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 Description of Change

Preserve complete menu item titles in the default slash menu.

- Prevent the title from shrinking or being ellipsized.
- Keep descriptions responsible for occupying remaining inline space and truncating with ellipsis.
- Preserve the single-line title + description layout.

#### 📝 Additional Information

Validation completed locally:

- `./node_modules/.bin/prettier --check src/plugins/slash/react/components/DefaultSlashMenu.tsx`
- `./node_modules/.bin/eslint src/plugins/slash/react/components/DefaultSlashMenu.tsx`
- `./node_modules/.bin/tsc --noEmit`
- `git diff --check`
- Commit hook also passed `type-check`, `lint:circular`, and lint-staged tasks.
