### PR TITLE
🐛 fix(toolbar): portal floating toolbar

### DIFF
--- a/src/plugins/toolbar/react/__tests__/ReactToolbarPlugin.test.tsx
+++ b/src/plugins/toolbar/react/__tests__/ReactToolbarPlugin.test.tsx
@@ -1,0 +1,195 @@
+import { act } from 'react';
+import type { DependencyList, ReactNode } from 'react';
+import { type Root, createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ReactToolbarPlugin } from '../';
+
+(globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT: boolean }).IS_REACT_ACT_ENVIRONMENT =
+  true;
+
+const mocks = vi.hoisted(() => {
+  const unregister = vi.fn();
+  const editorStateRead = vi.fn((callback: () => void) => callback());
+  const lexicalEditor = {
+    _window: undefined as undefined | Window,
+    dispatchCommand: vi.fn(),
+    getEditorState: vi.fn(() => ({
+      read: editorStateRead,
+    })),
+    getRootElement: vi.fn(() => document.createElement('div')),
+    registerCommand: vi.fn(() => unregister),
+    registerRootListener: vi.fn((listener: () => void) => {
+      listener();
+      return unregister;
+    }),
+    registerUpdateListener: vi.fn(() => unregister),
+    update: vi.fn((callback: () => void) => callback()),
+  };
+  const kernelEditor = {
+    requireService: vi.fn(() => null),
+  };
+
+  return {
+    editorStateRead,
+    kernelEditor,
+    lexicalEditor,
+    unregister,
+  };
+});
+
+vi.mock('lexical', async () => {
+  const actual = await vi.importActual<typeof import('lexical')>('lexical');
+
+  return {
+    ...actual,
+    $getSelection: vi.fn(() => null),
+    getDOMSelection: vi.fn(() => null),
+  };
+});
+
+vi.mock('@lobehub/ui', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    Block: React.forwardRef<HTMLDivElement, { children?: ReactNode }>(
+      ({ children, ...props }, ref) => (
+        <div ref={ref} {...props}>
+          {children}
+        </div>
+      ),
+    ),
+    LOBE_THEME_APP_ID: 'lobe-theme-app',
+  };
+});
+
+vi.mock('antd-style', () => ({
+  cx: (...classNames: Array<string | undefined>) => classNames.filter(Boolean).join(' '),
+  useThemeMode: () => ({ isDarkMode: false }),
+}));
+
+vi.mock('@/editor-kernel/react', async () => {
+  const React = await vi.importActual<typeof import('react')>('react');
+
+  return {
+    useLexicalComposerContext: () => [mocks.kernelEditor],
+    useLexicalEditor: (
+      handleEditor: (editor: typeof mocks.lexicalEditor) => (() => void) | undefined,
+      deps: DependencyList = [],
+    ) => {
+      React.useEffect(() => handleEditor(mocks.lexicalEditor), deps);
+    },
+  };
+});
+
+vi.mock('@/plugins/link', () => ({
+  ILinkService: Symbol('ILinkService'),
+}));
+
+vi.mock('../style', () => ({
+  styles: {
+    anchor: 'toolbar-anchor',
+    portalAnchor: 'toolbar-portal-anchor',
+    toolbarDark: 'toolbar-dark',
+    toolbarLight: 'toolbar-light',
+  },
+}));
+
+describe('ReactToolbarPlugin portal rendering', () => {
+  let host: HTMLDivElement;
+  let themeApp: HTMLDivElement;
+  let root: Root;
+
+  beforeEach(() => {
+    host = document.createElement('div');
+    themeApp = document.createElement('div');
+    themeApp.id = 'lobe-theme-app';
+    document.body.append(themeApp, host);
+    root = createRoot(host);
+    mocks.lexicalEditor._window = window;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    act(() => {
+      root.unmount();
+    });
+    host.remove();
+    themeApp.remove();
+  });
+
+  it('renders the toolbar into the theme app container by default', async () => {
+    await act(async () => {
+      root.render(
+        <ReactToolbarPlugin>
+          <button data-testid="toolbar-action" type="button" />
+        </ReactToolbarPlugin>,
+      );
+    });
+
+    expect(themeApp.querySelector('[data-testid="toolbar-action"]')).not.toBeNull();
+    expect(host.querySelector('[data-testid="toolbar-action"]')).toBeNull();
+  });
+
+  it('renders the toolbar into a custom popup container', async () => {
+    const customContainer = document.createElement('div');
+    document.body.append(customContainer);
+
+    await act(async () => {
+      root.render(
+        <ReactToolbarPlugin getPopupContainer={() => customContainer}>
+          <button data-testid="toolbar-action" type="button" />
+        </ReactToolbarPlugin>,
+      );
+    });
+
+    expect(customContainer.querySelector('[data-testid="toolbar-action"]')).not.toBeNull();
+    expect(themeApp.querySelector('[data-testid="toolbar-action"]')).toBeNull();
+
+    customContainer.remove();
+  });
+
+  it('renders locally when portal rendering is disabled', async () => {
+    await act(async () => {
+      root.render(
+        <ReactToolbarPlugin usePortal={false}>
+          <button data-testid="toolbar-action" type="button" />
+        </ReactToolbarPlugin>,
+      );
+    });
+
+    expect(host.querySelector('[data-testid="toolbar-action"]')).not.toBeNull();
+    expect(themeApp.querySelector('[data-testid="toolbar-action"]')).toBeNull();
+  });
+
+  it('recomputes the toolbar position after scrolling', async () => {
+    const requestAnimationFrameSpy = vi
+      .spyOn(window, 'requestAnimationFrame')
+      .mockImplementation((callback) => {
+        callback(0);
+        return 1;
+      });
+    const cancelAnimationFrameSpy = vi
+      .spyOn(window, 'cancelAnimationFrame')
+      .mockImplementation(() => {});
+
+    await act(async () => {
+      root.render(
+        <ReactToolbarPlugin>
+          <button data-testid="toolbar-action" type="button" />
+        </ReactToolbarPlugin>,
+      );
+    });
+
+    mocks.editorStateRead.mockClear();
+
+    await act(async () => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    expect(mocks.editorStateRead).toHaveBeenCalledTimes(1);
+
+    requestAnimationFrameSpy.mockRestore();
+    cancelAnimationFrameSpy.mockRestore();
+  });
+});

--- a/src/plugins/toolbar/react/index.tsx
+++ b/src/plugins/toolbar/react/index.tsx
@@ -1,5 +1,5 @@
 import { mergeRegister } from '@lexical/utils';
-import { Block } from '@lobehub/ui';
+import { Block, LOBE_THEME_APP_ID } from '@lobehub/ui';
 import { cx, useThemeMode } from 'antd-style';
 import {
   $getSelection,
@@ -8,7 +8,8 @@ import {
   SELECTION_CHANGE_COMMAND,
   getDOMSelection,
 } from 'lexical';
-import { FC, useCallback, useRef } from 'react';
+import { FC, useCallback, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 
 import { useLexicalComposerContext, useLexicalEditor } from '@/editor-kernel/react';
 import { ILinkService } from '@/plugins/link';
@@ -20,13 +21,36 @@ import { setFloatingElemPosition } from '../utils/setFloatingElemPosition';
 import { styles } from './style';
 import { ReactToolbarPluginProps } from './type';
 
-export const ReactToolbarPlugin: FC<ReactToolbarPluginProps> = ({ className, children }) => {
+const resolveDefaultPortalContainer = (): HTMLElement | null => {
+  if (typeof document === 'undefined') return null;
+  return document.getElementById(LOBE_THEME_APP_ID) ?? document.body;
+};
+
+export const ReactToolbarPlugin: FC<ReactToolbarPluginProps> = ({
+  className,
+  children,
+  getPopupContainer,
+  usePortal = true,
+  zIndex,
+}) => {
   const popupCharStylesEditorRef = useRef<HTMLDivElement | null>(null);
   const anchorElemRef = useRef<HTMLDivElement | null>(null);
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
   const [kernelEditor] = useLexicalComposerContext();
   const { isDarkMode } = useThemeMode();
   const isMouseDownRef = useRef(false);
   const logger = createDebugLogger('plugin', 'toolbar');
+
+  const resolvePortalContainer = useCallback(() => {
+    if (!usePortal) return null;
+    if (getPopupContainer) return getPopupContainer();
+    return resolveDefaultPortalContainer();
+  }, [getPopupContainer, usePortal]);
+
+  const syncPortalContainer = useCallback(() => {
+    const nextContainer = resolvePortalContainer();
+    setPortalContainer((current) => (current === nextContainer ? current : nextContainer));
+  }, [resolvePortalContainer]);
 
   const $updateTextFormatFloatingToolbar = useCallback(
     (editor: LexicalEditor) => {
@@ -112,6 +136,20 @@ export const ReactToolbarPlugin: FC<ReactToolbarPluginProps> = ({ className, chi
     }
   }, []);
 
+  useLexicalEditor(
+    (editor) => {
+      if (!usePortal) {
+        setPortalContainer(null);
+        return;
+      }
+
+      syncPortalContainer();
+
+      return editor.registerRootListener(syncPortalContainer);
+    },
+    [syncPortalContainer, usePortal],
+  );
+
   useLexicalEditor((editor) => {
     const handleMouseDown = handleMouseDownFactory(() => {
       editor.dispatchCommand(HIDE_TOOLBAR_COMMAND, undefined);
@@ -123,9 +161,37 @@ export const ReactToolbarPlugin: FC<ReactToolbarPluginProps> = ({ className, chi
     });
 
     const rootElement = editor.getRootElement();
+    const editorWindow =
+      editor._window ?? rootElement?.ownerDocument.defaultView ?? globalThis.window ?? null;
+    let animationFrameId: number | null = null;
+    const updateToolbarPosition = () => {
+      if (!editorWindow || isMouseDownRef.current || animationFrameId !== null) {
+        return;
+      }
+
+      animationFrameId = editorWindow.requestAnimationFrame(() => {
+        animationFrameId = null;
+        editor.getEditorState().read(() => {
+          $updateTextFormatFloatingToolbar(editor);
+        });
+      });
+    };
+    const scrollListenerOptions = { capture: true, passive: true } as const;
+    const scrollCleanupOptions = { capture: true } as const;
+    const resizeListenerOptions = { passive: true } as const;
+
     if (rootElement) {
       rootElement.addEventListener('mousedown', handleMouseDown);
       document.addEventListener('mouseup', handleMouseUp);
+    }
+    if (editorWindow) {
+      editorWindow.addEventListener('scroll', updateToolbarPosition, scrollListenerOptions);
+      editorWindow.document.addEventListener(
+        'scroll',
+        updateToolbarPosition,
+        scrollListenerOptions,
+      );
+      editorWindow.addEventListener('resize', updateToolbarPosition, resizeListenerOptions);
     }
 
     return mergeRegister(
@@ -159,12 +225,28 @@ export const ReactToolbarPlugin: FC<ReactToolbarPluginProps> = ({ className, chi
           rootElement.removeEventListener('mousedown', handleMouseDown);
           document.removeEventListener('mouseup', handleMouseUp);
         }
+        if (editorWindow) {
+          editorWindow.removeEventListener('scroll', updateToolbarPosition, scrollCleanupOptions);
+          editorWindow.document.removeEventListener(
+            'scroll',
+            updateToolbarPosition,
+            scrollCleanupOptions,
+          );
+          editorWindow.removeEventListener('resize', updateToolbarPosition);
+          if (animationFrameId !== null) {
+            editorWindow.cancelAnimationFrame(animationFrameId);
+          }
+        }
       },
     );
   });
 
-  return (
-    <div className={styles.anchor} ref={anchorElemRef}>
+  const toolbarNode = (
+    <div
+      className={usePortal ? styles.portalAnchor : styles.anchor}
+      ref={anchorElemRef}
+      style={usePortal && zIndex !== undefined ? { zIndex } : undefined}
+    >
       <Block
         className={cx(isDarkMode ? styles.toolbarDark : styles.toolbarLight, className)}
         padding={4}
@@ -175,4 +257,10 @@ export const ReactToolbarPlugin: FC<ReactToolbarPluginProps> = ({ className, chi
       </Block>
     </div>
   );
+
+  if (usePortal) {
+    return portalContainer ? createPortal(toolbarNode, portalContainer) : null;
+  }
+
+  return toolbarNode;
 };

--- a/src/plugins/toolbar/react/style.ts
+++ b/src/plugins/toolbar/react/style.ts
@@ -4,7 +4,14 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
   anchor: css`
     position: relative;
   `,
+  portalAnchor: css`
+    pointer-events: none;
+    position: fixed;
+    z-index: 1100;
+    inset: 0;
+  `,
   toolbarDark: css`
+    pointer-events: auto;
     will-change: transform;
 
     position: absolute;
@@ -28,6 +35,7 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     transition: opacity 0.12s ${cssVar.motionEaseOut};
   `,
   toolbarLight: css`
+    pointer-events: auto;
     will-change: transform;
 
     position: absolute;

--- a/src/plugins/toolbar/react/type.ts
+++ b/src/plugins/toolbar/react/type.ts
@@ -1,6 +1,9 @@
-import { ReactNode } from 'react';
+import { CSSProperties, ReactNode } from 'react';
 
 export interface ReactToolbarPluginProps {
   children?: ReactNode;
   className?: string;
+  getPopupContainer?: () => HTMLElement | null;
+  usePortal?: boolean;
+  zIndex?: CSSProperties['zIndex'];
 }


### PR DESCRIPTION
## Summary

- Render `ReactToolbarPlugin` through a portal by default so the floating selection toolbar is not clipped by business containers.
- Add `getPopupContainer`, `usePortal`, and `zIndex` options for integration control and fallback behavior.
- Recompute toolbar position on scroll and resize using a requestAnimationFrame-throttled path.
- Add regression coverage for default portal rendering, custom containers, local rendering, and scroll-triggered position recalculation.

## Root Cause

The selection toolbar was rendered as a normal sibling inside the editor tree. In business layouts with overflow or local stacking contexts, that local DOM placement could clip or cover the floating toolbar. After moving the toolbar to a portal, scroll also needed to become an explicit invalidation source because selection/update events do not necessarily fire when a nested container scrolls.

## Verification

- `pnpm exec vitest run src/plugins/toolbar/react/__tests__/ReactToolbarPlugin.test.tsx`
- `pnpm exec eslint src/plugins/toolbar/react/index.tsx src/plugins/toolbar/react/type.ts src/plugins/toolbar/react/__tests__/ReactToolbarPlugin.test.tsx`
- `pnpm exec tsc --noEmit --pretty false`
- `pnpm exec prettier --check src/plugins/toolbar/react/index.tsx src/plugins/toolbar/react/style.ts src/plugins/toolbar/react/type.ts src/plugins/toolbar/react/__tests__/ReactToolbarPlugin.test.tsx`
- `git diff --check`