### PR TITLE
🐛 fix(markdown): preserve LaTeX escapes during serialization

### DIFF
--- a/src/headless/__tests__/headless-editor.test.ts
+++ b/src/headless/__tests__/headless-editor.test.ts
@@ -114,6 +114,33 @@ describe('HeadlessEditor', () => {
     expect(findTextNode(editorData.root, 'Second')).not.toBeNull();
   });
 
+  it('preserves LaTeX syntax in Markdown projection', () => {
+    const editor = createHeadlessEditor();
+    const markdown = String.raw`$$
+\boxed
+$$
+
+$$
+\boxed{48}
+$$
+
+$$
+abc \;\Longleftrightarrow\; xyz
+$$
+
+$$
+\begin{cases}
+x = 1 \\[2pt]
+y = 2
+\end{cases}
+$$`;
+
+    editor.hydrateMarkdown(markdown);
+
+    expect(editor.export().markdown).toBe(`${markdown}\n`);
+    editor.destroy();
+  });
+
   it('preserves Markdown links in headless editor data and Markdown projection', () => {
     const editor = createHeadlessEditor();
     const url = 'https://github.com/lobehub/lobehub/pull/14436';

--- a/src/plugins/markdown/data-source/markdown-data-source.ts
+++ b/src/plugins/markdown/data-source/markdown-data-source.ts
@@ -15,7 +15,9 @@ import {
   $isTextNode,
 } from 'lexical';
 import { remark } from 'remark';
+import remarkCjkFriendly from 'remark-cjk-friendly';
 import remarkGfm from 'remark-gfm';
+import remarkMath from 'remark-math';
 
 import { DataSource } from '@/editor-kernel';
 import type { IWriteOptions } from '@/editor-kernel/data-source';
@@ -32,6 +34,8 @@ export default class MarkdownDataSource extends DataSource {
   private formatMarkdown(markdown: string): string {
     try {
       const result = remark()
+        .use(remarkCjkFriendly)
+        .use(remarkMath)
         .use([[remarkGfm, { singleTilde: false }]])
         .data('settings', {
           bullet: '-',


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

## Changes

- Add `remarkMath` to the Markdown formatting pipeline so LaTeX blocks are recognized during serialization.
- Add `remarkCjkFriendly` to keep the formatting pipeline consistent with the existing Markdown parsing pipeline.
- Add regression coverage for `\boxed`, `\;`, `\Longleftrightarrow`, and `\\[2pt]`.
- Preserve the existing `remarkGfm` configuration and unrelated Markdown behavior.

## Root Cause

`MarkdownDataSource.formatMarkdown()` formatted exported content using `remarkGfm` without `remarkMath`. As a result, LaTeX blocks were treated as plain Markdown: spacing commands such as `\;` lost their backslashes, while line-break syntax such as `\\[2pt]` was escaped again.

## Before

- `\;\Longleftrightarrow\;` could become `;\Longleftrightarrow;`.
- `\\[2pt]` could gain an extra backslash.
- The saved message rendered differently from the editor preview.

## After

- Math blocks are recognized during Markdown serialization.
- LaTeX backslashes are preserved.
- The exported Markdown matches the editor content.

#### 📝 补充信息 | Additional Information

## Test

```bash
pnpm exec vitest run --silent='passed-only' src/headless/__tests__/headless-editor.test.ts
pnpm run type-check
pnpm run lint:circular
pnpm exec prettier --check src/plugins/markdown/data-source/markdown-data-source.ts src/headless/__tests__/headless-editor.test.ts
```

- [x] Tested locally: 15 tests passed
- [x] Added a regression test
- [x] Type checking passes
- [x] Circular dependency checking passes
- [x] Prettier checking passes

This draft overlaps with #124 and adds regression coverage for the cases reported in lobehub/lobehub#18045. It is intentionally left as a draft so maintainers can decide whether to use this PR or incorporate the test coverage into #124.

Fixes lobehub/lobehub#18045
