### PR TITLE
🐛 fix(slash): preserve typeahead scope during search

### DIFF
--- a/src/plugins/slash/demos/fileTypeahead.tsx
+++ b/src/plugins/slash/demos/fileTypeahead.tsx
@@ -1,6 +1,8 @@
 import {
+  INSERT_MENTION_COMMAND,
   ReactEditor,
   ReactEditorContent,
+  ReactMentionPlugin,
   ReactPlainText,
   ReactSlashOption,
   ReactSlashPlugin,
@@ -26,6 +28,7 @@ export default () => {
           type={'text'}
         />
       </ReactPlainText>
+      <ReactMentionPlugin />
       <ReactSlashPlugin>
         <ReactSlashOption
           items={async (search) => {
@@ -34,8 +37,11 @@ export default () => {
             const query = search?.matchingString.toLowerCase() ?? '';
             return FILE_OPTIONS.filter((option) => option.key.toLowerCase().includes(query));
           }}
-          onSelect={(_, option) => {
-            console.info('Selected file:', option.key);
+          onSelect={(editor, option) => {
+            editor.dispatchCommand(INSERT_MENTION_COMMAND, {
+              label: String(option.label),
+              metadata: { path: option.key },
+            });
           }}
           trigger={'@'}
         />

--- a/src/plugins/slash/demos/fileTypeahead.tsx
+++ b/src/plugins/slash/demos/fileTypeahead.tsx
@@ -1,0 +1,52 @@
+import {
+  ReactEditor,
+  ReactEditorContent,
+  ReactPlainText,
+  ReactSlashOption,
+  ReactSlashPlugin,
+} from '@lobehub/editor';
+
+const FILE_OPTIONS = [
+  'src/components/Editor.tsx',
+  'src/components/SlashMenu.tsx',
+  'src/plugins/slash/plugin/index.ts',
+  'src/plugins/slash/react/ReactSlashPlugin.tsx',
+  'src/plugins/slash/service/i-slash-service.ts',
+  'src/plugins/slash/utils/utils.ts',
+  'tests/plugins/slash/typeahead.test.ts',
+].map((path) => ({ key: path, label: path }));
+
+export default () => {
+  return (
+    <ReactEditor>
+      <ReactPlainText>
+        <ReactEditorContent
+          content={''}
+          placeholder={'Type @src/ to search files, or / to open commands'}
+          type={'text'}
+        />
+      </ReactPlainText>
+      <ReactSlashPlugin>
+        <ReactSlashOption
+          items={async (search) => {
+            await new Promise((resolve) => setTimeout(resolve, 600));
+
+            const query = search?.matchingString.toLowerCase() ?? '';
+            return FILE_OPTIONS.filter((option) => option.key.toLowerCase().includes(query));
+          }}
+          onSelect={(_, option) => {
+            console.info('Selected file:', option.key);
+          }}
+          trigger={'@'}
+        />
+        <ReactSlashOption
+          items={[
+            { key: 'summarize', label: 'Summarize' },
+            { key: 'translate', label: 'Translate' },
+          ]}
+          trigger={'/'}
+        />
+      </ReactSlashPlugin>
+    </ReactEditor>
+  );
+};

--- a/src/plugins/slash/index.mdx
+++ b/src/plugins/slash/index.mdx
@@ -4,6 +4,7 @@ description: Slash plugin enables powerful slash commands (/command) in the edit
 category: Plugins
 ---
 
+import DemoFileTypeahead from './demos/fileTypeahead.tsx?demo';
 import DemoIndex from './demos/index.tsx?demo';
 
 ## Introduction
@@ -13,6 +14,16 @@ Slash plugin provides a sophisticated slash command system that allows users to 
 ## Basic Usage
 
 <Demo of={DemoIndex} />
+
+## Async File Typeahead
+
+This demo registers both `@` file search and `/` commands. The file search intentionally waits 600 ms so the loading transition remains observable.
+
+- Type `@src/components/` to verify that path separators remain in the file-search scope.
+- Continue typing while a request is pending to verify that the previous results remain visible.
+- Type `@src/components!` to close the scope, then backspace over `!` to verify that file search reopens.
+
+<Demo of={DemoFileTypeahead} />
 
 ## Core Architecture
 

--- a/src/plugins/slash/plugin/index.ts
+++ b/src/plugins/slash/plugin/index.ts
@@ -212,8 +212,7 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
             // Do not trigger inside code
             selection.hasFormat('code') ||
             text === null ||
-            range === null ||
-            (this.currentSlashTrigger === null && text.length > 1 && text.at(-2) !== ' ')
+            range === null
           ) {
             this.triggerClose();
             return;
@@ -227,8 +226,14 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
 
           let triggerText = this.currentSlashTrigger;
           if (triggerText === null) {
-            triggerText = text.slice(-1);
-            this.currentSlashTriggerIndex = text.length - 1;
+            const resolution = this.service?.resolveTrigger(text);
+            if (!resolution) {
+              this.triggerClose();
+              return;
+            }
+
+            triggerText = resolution.trigger;
+            this.currentSlashTriggerIndex = resolution.leadOffset;
           }
           const lastIndex = text.lastIndexOf(triggerText);
           if (lastIndex < this.currentSlashTriggerIndex) {
@@ -253,6 +258,11 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
           );
           const match = triggerFn?.(text.slice(this.currentSlashTriggerIndex));
 
+          if (!match) {
+            this.triggerClose();
+            return;
+          }
+
           // Check if there's a space in the current search text that should close the menu
           const searchText = text.slice(this.currentSlashTriggerIndex);
           const hasSpaceAfterTrigger = searchText.includes(' ') && !slashOptions?.allowWhitespace;
@@ -263,7 +273,7 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
           }
 
           const finalItems =
-            fuse && match && match.matchingString.length > 0
+            fuse && match.matchingString.length > 0
               ? fuse.search(match.matchingString).map((result) => result.item)
               : slashOptions.items;
           if (isRangePositioned !== null && finalItems.length > 0) {

--- a/src/plugins/slash/react/components/DefaultSlashMenu.tsx
+++ b/src/plugins/slash/react/components/DefaultSlashMenu.tsx
@@ -21,6 +21,7 @@ import {
   isSlashSectionOption,
 } from '../../service/i-slash-service';
 import type { SlashMenuProps } from '../type';
+import { shouldShowLoadingPlaceholder } from './menuLoading';
 
 const styles = createStaticStyles(({ css, cssVar }) => ({
   popup: css`
@@ -145,7 +146,11 @@ const renderItems = (
   loading: boolean | undefined,
   onSelect: (option: ISlashMenuOption) => void,
 ): ReactNode => {
-  if (loading) return <div className={menuSharedStyles.empty}>Loading...</div>;
+  // Async searches retain their previous options. Keep rendering those options
+  // while the next query is loading instead of flashing a transient placeholder.
+  if (shouldShowLoadingPlaceholder(loading, options)) {
+    return <div className={menuSharedStyles.empty}>Loading...</div>;
+  }
   return options.map((opt, index) => {
     if (isSlashDividerOption(opt)) {
       return <div className={menuSharedStyles.separator} key={`__divider_${index}`} />;

--- a/src/plugins/slash/react/components/menuLoading.test.ts
+++ b/src/plugins/slash/react/components/menuLoading.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+
+import { shouldShowLoadingPlaceholder } from './menuLoading';
+
+describe('shouldShowLoadingPlaceholder', () => {
+  it('keeps rendering previous results while the next query loads', () => {
+    const previousResults = [{ key: 'file-a', label: 'file-a.ts' }];
+
+    expect(shouldShowLoadingPlaceholder(true, previousResults)).toBe(false);
+  });
+
+  it('allows a loading placeholder when no previous result exists', () => {
+    expect(shouldShowLoadingPlaceholder(true, [])).toBe(true);
+  });
+});

--- a/src/plugins/slash/react/components/menuLoading.ts
+++ b/src/plugins/slash/react/components/menuLoading.ts
@@ -1,0 +1,6 @@
+import type { ISlashOption } from '../../service/i-slash-service';
+
+export const shouldShowLoadingPlaceholder = (
+  loading: boolean | undefined,
+  options: ISlashOption[],
+): boolean => Boolean(loading && options.length === 0);

--- a/src/plugins/slash/service/i-slash-service.test.ts
+++ b/src/plugins/slash/service/i-slash-service.test.ts
@@ -1,0 +1,46 @@
+import type { IEditorKernel } from '@/types';
+import { describe, expect, it } from 'vitest';
+
+import { SlashService } from './i-slash-service';
+
+const createService = () => new SlashService({ isHotReloadMode: () => false } as IEditorKernel);
+
+const registerDefaultTriggers = (service: SlashService) => {
+  service.registerSlash({ items: [], trigger: '/' });
+  service.registerSlash({ items: [], trigger: '@' });
+};
+
+describe('SlashService', () => {
+  it('keeps path separators inside a non-slash trigger query', () => {
+    const service = createService();
+    registerDefaultTriggers(service);
+
+    const resolution = service.resolveTrigger('@src/components/Button');
+    const match = service.getSlashTriggerFn('@')?.('@src/components/Button');
+
+    expect(resolution).toEqual({ leadOffset: 0, trigger: '@' });
+    expect(match?.matchingString).toBe('src/components/Button');
+  });
+
+  it('still recognizes slash commands after allowing path separators', () => {
+    const service = createService();
+    registerDefaultTriggers(service);
+
+    expect(service.resolveTrigger('run /review')).toEqual({ leadOffset: 4, trigger: '/' });
+  });
+
+  it('recovers an existing trigger after backspace removes an invalid boundary', () => {
+    const service = createService();
+    registerDefaultTriggers(service);
+
+    expect(service.resolveTrigger('@source!')).toBeNull();
+    expect(service.resolveTrigger('@source')).toEqual({ leadOffset: 0, trigger: '@' });
+  });
+
+  it('does not activate embedded trigger characters', () => {
+    const service = createService();
+    registerDefaultTriggers(service);
+
+    expect(service.resolveTrigger('mail@example.com')).toBeNull();
+  });
+});

--- a/src/plugins/slash/service/i-slash-service.ts
+++ b/src/plugins/slash/service/i-slash-service.ts
@@ -78,8 +78,14 @@ export interface SlashOptions {
   trigger: string;
 }
 
+export interface SlashTriggerResolution {
+  leadOffset: number;
+  trigger: string;
+}
+
 export interface ISlashService {
   registerSlash(options: SlashOptions): void;
+  resolveTrigger(text: string): SlashTriggerResolution | null;
   updateOptions(options: SlashOptions[]): void;
 }
 
@@ -130,6 +136,19 @@ export class SlashService implements ISlashService {
     this.triggerMap.clear();
     this.triggerFnMap.clear();
     this.triggerFuseMap.clear();
+  }
+
+  resolveTrigger(text: string): SlashTriggerResolution | null {
+    let resolution: SlashTriggerResolution | null = null;
+
+    for (const [trigger, triggerFn] of this.triggerFnMap) {
+      const match = triggerFn(text);
+      if (!match || (resolution && match.leadOffset <= resolution.leadOffset)) continue;
+
+      resolution = { leadOffset: match.leadOffset, trigger };
+    }
+
+    return resolution;
   }
 
   updateOptions(options: SlashOptions[]): void {

--- a/src/plugins/slash/utils/utils.ts
+++ b/src/plugins/slash/utils/utils.ts
@@ -121,7 +121,10 @@ export const scrollIntoViewIfNeeded = (target: HTMLElement) => {
   target.scrollIntoView({ block: 'nearest' });
 };
 
-export const PUNCTUATION = '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\-\\[\\]\\\\/!%\'"~=<>_:;';
+// `/` remains a valid query character for non-slash triggers so typeaheads such
+// as `@src/components/Button` can search path-like values. A `/` trigger still
+// excludes the character through the trigger-specific part of the matcher.
+export const PUNCTUATION = '\\.,\\+\\*\\?\\$\\@\\|#{}\\(\\)\\^\\-\\[\\]\\\\!%\'"~=<>_:;';
 
 export function getBasicTypeaheadTriggerMatch(
   trigger: string,


### PR DESCRIPTION
## Summary

- keep path separators inside non-slash typeahead queries, so file mentions such as `@src/components/Button` remain in the `@` scope
- resolve registered triggers from the full cursor-prefix text, allowing an existing `@` scope to reopen after backspacing across an invalid boundary
- retain the previous option list during asynchronous loading instead of flashing a loading placeholder
- add regression coverage for path queries, slash commands, backspace recovery, embedded triggers, and loading behavior
- add an interactive async file-typeahead demo under the Slash documentation for manual verification

## Root cause

The shared punctuation matcher treated `/` as a query terminator for every trigger, while the plugin only recognized a new scope from the final typed character. Once the active scope closed, backspacing into a valid existing scope could not rediscover it. The default menu also replaced existing options whenever a new asynchronous query entered the loading state.

## Demo

Open the **Async File Typeahead** section on the Slash documentation page:

- type `@src/components/` to verify that path separators stay in the file-search scope
- continue typing during the 600 ms simulated request to verify that previous results remain visible
- type `@src/components!`, then backspace over `!`, to verify that the `@` search reopens
- type `/` separately to verify that slash commands still open normally

## Validation

- `pnpm exec vitest run --silent='passed-only' src/plugins/slash/service/i-slash-service.test.ts src/plugins/slash/react/components/menuLoading.test.ts` — 6 tests passed
- `pnpm exec tsc --noEmit`
- `pnpm run build`
- `pnpm run docs:build`
- `pnpm run lint:circular`
- targeted ESLint — 0 errors
- `git diff --check`

The full Vitest run completed with 314 passing tests and two unrelated existing Mermaid SSR assertion failures in `src/renderer/__tests__/LexicalRenderer.test.tsx`.