### PR TITLE
✨ feat(math): make inline parsing configurable

### DIFF
--- a/src/plugins/math/__tests__/math.test.ts
+++ b/src/plugins/math/__tests__/math.test.ts
@@ -6,6 +6,35 @@ import { MarkdownPlugin } from '@/plugins/markdown/plugin';
 import { MathPlugin } from '../plugin';
 
 describe('Math plugin', () => {
+  it('should keep inline math markdown as text when inline math is disabled', () => {
+    const editor = new Kernel();
+    editor.registerPlugins([
+      MarkdownPlugin,
+      CommonPlugin,
+      [MathPlugin, { enableInlineMath: false }],
+    ]);
+
+    editor.setRootElement(document.createElement('div'));
+    editor.setDocument('markdown', 'Budget variable: $x$');
+
+    expect(editor.getDocument('text')).toBe('Budget variable: $x$');
+    expect(JSON.stringify(editor.getDocument('json'))).not.toContain('"type":"math"');
+  });
+
+  it('should preserve block math parsing when inline math is disabled', () => {
+    const editor = new Kernel();
+    editor.registerPlugins([
+      MarkdownPlugin,
+      CommonPlugin,
+      [MathPlugin, { enableInlineMath: false }],
+    ]);
+
+    editor.setRootElement(document.createElement('div'));
+    editor.setDocument('markdown', '$$\nE=mc^2\n$$');
+
+    expect(JSON.stringify(editor.getDocument('json'))).toContain('"type":"mathBlock"');
+  });
+
   it('should math markdown writer work', () => {
     const editor = new Kernel();
     editor.registerPlugins([MarkdownPlugin, CommonPlugin, MathPlugin]);

--- a/src/plugins/math/plugin/index.ts
+++ b/src/plugins/math/plugin/index.ts
@@ -19,6 +19,8 @@ import { isLikelyMathContent } from '../utils';
 
 export interface MathPluginOptions {
   decorator?: (node: MathInlineNode | MathBlockNode, editor: LexicalEditor) => unknown;
+  /** Enable `$...$` shortcuts and Markdown inline-math parsing. Defaults to true. */
+  enableInlineMath?: boolean;
   theme?: {
     mathBlock?: string;
     mathInline?: string;
@@ -107,26 +109,28 @@ export const MathPlugin: IEditorPluginConstructor<MathPluginOptions> = class
   registerMarkdown() {
     const markdownService = this.kernel.requireService(IMarkdownShortCutService);
 
-    markdownService?.registerMarkdownShortCut({
-      regExp: /\$([^\s$](?:[^$]*[^\s$])?)\$\s?$/,
-      replace: (textNode, match) => {
-        const [, code] = match;
+    if (this.config?.enableInlineMath !== false) {
+      markdownService?.registerMarkdownShortCut({
+        regExp: /\$([^\s$](?:[^$]*[^\s$])?)\$\s?$/,
+        replace: (textNode, match) => {
+          const [, code] = match;
 
-        if (!isLikelyMathContent(code)) return;
+          if (!isLikelyMathContent(code)) return;
 
-        const mathNode = $createMathInlineNode(code);
-        this.logger.debug('Math node inserted:', mathNode);
-        // textNode.replace(mathNode);
-        textNode.insertBefore(mathNode);
-        textNode.setTextContent('');
-        textNode.select();
-        // mathNode.selectEnd();
+          const mathNode = $createMathInlineNode(code);
+          this.logger.debug('Math node inserted:', mathNode);
+          // textNode.replace(mathNode);
+          textNode.insertBefore(mathNode);
+          textNode.setTextContent('');
+          textNode.select();
+          // mathNode.selectEnd();
 
-        return;
-      },
-      trigger: '$',
-      type: 'text-match',
-    });
+          return;
+        },
+        trigger: '$',
+        type: 'text-match',
+      });
+    }
 
     markdownService?.registerMarkdownShortCut({
       regExp: /^(\$\$)$/,
@@ -158,12 +162,14 @@ export const MathPlugin: IEditorPluginConstructor<MathPluginOptions> = class
       return true;
     });
 
-    markdownService?.registerMarkdownReader('inlineMath', (node) => {
-      return INodeHelper.createElementNode('math', {
-        code: node.value,
-        version: 1,
+    if (this.config?.enableInlineMath !== false) {
+      markdownService?.registerMarkdownReader('inlineMath', (node) => {
+        return INodeHelper.createElementNode('math', {
+          code: node.value,
+          version: 1,
+        });
       });
-    });
+    }
 
     markdownService?.registerMarkdownReader('math', (node) => {
       return INodeHelper.createElementNode('mathBlock', {

--- a/src/plugins/math/react/index.tsx
+++ b/src/plugins/math/react/index.tsx
@@ -11,18 +11,24 @@ import MathInline from './components/MathInline';
 import { styles } from './style';
 import type { ReactMathPluginProps } from './type';
 
-export const ReactMathPlugin: FC<ReactMathPluginProps> = ({ className, renderComp, theme }) => {
+export const ReactMathPlugin: FC<ReactMathPluginProps> = ({
+  className,
+  enableInlineMath,
+  renderComp,
+  theme,
+}) => {
   const [editor] = useLexicalComposerContext();
 
   useLayoutEffect(() => {
     editor.registerPlugin(MarkdownPlugin);
     editor.registerPlugin(MathPlugin, {
+      enableInlineMath,
       decorator: (node, editor) => {
         return <MathInline className={className} editor={editor} node={node} />;
       },
       theme: theme || styles,
     });
-  }, [editor, className, theme, styles]);
+  }, [editor, className, enableInlineMath, theme]);
 
   return <MathEdit renderComp={renderComp} />;
 };

--- a/src/plugins/math/react/type.ts
+++ b/src/plugins/math/react/type.ts
@@ -2,6 +2,8 @@ import type { FC, ReactNode } from 'react';
 
 export interface ReactMathPluginProps {
   className?: string;
+  /** Enable `$...$` shortcuts and Markdown inline-math parsing. Defaults to true. */
+  enableInlineMath?: boolean;
   /** 自定义渲染组件，接收 MathEditorContent 作为子节点 */
   renderComp?: FC<{ children: ReactNode; open?: boolean }>;
   theme?: {


### PR DESCRIPTION
## Summary
- add `enableInlineMath` to MathPlugin and ReactMathPlugin
- disable `$...$` shortcut and Markdown inline-math parsing when false
- preserve block math and existing math node support

## Tests
- `pnpm exec vitest run src/plugins/math/__tests__/math.test.ts --silent=passed-only`
- `pnpm run type-check`