### PR TITLE
🐛 fix(renderer): render table column widths from colWidths

### DIFF
--- a/src/renderer/__tests__/LexicalDiff.test.tsx
+++ b/src/renderer/__tests__/LexicalDiff.test.tsx
@@ -60,13 +60,7 @@ function makeHeading(text: string, tag: 'h1' | 'h2' | 'h3' = 'h1') {
 
 function makeDiffNode(
   diffType:
-    | 'add'
-    | 'remove'
-    | 'modify'
-    | 'unchanged'
-    | 'listItemModify'
-    | 'listItemRemove'
-    | 'listItemAdd',
+    'add' | 'remove' | 'modify' | 'unchanged' | 'listItemModify' | 'listItemRemove' | 'listItemAdd',
   children: any[],
 ) {
   return {
@@ -99,6 +93,36 @@ function makeList(items: string[], listType: 'bullet' | 'number' = 'bullet') {
     start: 1,
     tag: listType === 'number' ? 'ol' : 'ul',
     type: 'list',
+    version: 1,
+  };
+}
+
+function makeTable(rows: string[][], colWidths: number[]) {
+  return {
+    children: rows.map((cells) => ({
+      children: cells.map((text) => ({
+        backgroundColor: null,
+        children: [makeParagraph(text)],
+        colSpan: 1,
+        direction: 'ltr',
+        format: '',
+        headerState: 0,
+        indent: 0,
+        rowSpan: 1,
+        type: 'tablecell',
+        version: 1,
+      })),
+      direction: 'ltr',
+      format: '',
+      indent: 0,
+      type: 'tablerow',
+      version: 1,
+    })),
+    colWidths,
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'table',
     version: 1,
   };
 }
@@ -358,6 +382,19 @@ describe('LexicalDiff', () => {
     expect(overrideHtml).toContain('<section');
     expect(overrideHtml).toContain('override');
     expect(overrideHtml).toContain('--ant-color-success');
+  });
+
+  it('keeps table column widths on both sides', () => {
+    const html = renderToStaticMarkup(
+      <LexicalDiff
+        newValue={makeEditorState([makeTable([['a', 'b']], [375, 375])])}
+        oldValue={makeEditorState([makeTable([['a', 'b']], [200, 550])])}
+      />,
+    );
+
+    expect(html).toContain('<col style="width:200px"/>');
+    expect(html).toContain('<col style="width:550px"/>');
+    expect(html).toContain('<col style="width:375px"/>');
   });
 
   it('renders serialized diff nodes through the inner LexicalRenderer', () => {

--- a/src/renderer/__tests__/LexicalRenderer.test.tsx
+++ b/src/renderer/__tests__/LexicalRenderer.test.tsx
@@ -416,6 +416,59 @@ describe('LexicalRenderer', () => {
     expect(html).toContain('item 2');
   });
 
+  it('renders table colgroup from serialized colWidths', () => {
+    const cell = (text: string) => ({
+      backgroundColor: null,
+      children: [
+        {
+          children: [
+            { detail: 0, format: 0, mode: 'normal', style: '', text, type: 'text', version: 1 },
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          textFormat: 0,
+          textStyle: '',
+          type: 'paragraph',
+          version: 1,
+        },
+      ],
+      colSpan: 1,
+      direction: 'ltr',
+      format: '',
+      headerState: 0,
+      indent: 0,
+      rowSpan: 1,
+      type: 'tablecell',
+      version: 1,
+    });
+
+    const value = makeEditorState([
+      {
+        children: [
+          {
+            children: [cell('a'), cell('b')],
+            direction: 'ltr',
+            format: '',
+            indent: 0,
+            type: 'tablerow',
+            version: 1,
+          },
+        ],
+        colWidths: [375, 375],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'table',
+        version: 1,
+      },
+    ]);
+
+    const html = toHTML(value);
+    expect(html).toContain('<colgroup>');
+    expect(html).toContain('<col style="width:375px"/>');
+  });
+
   it('applies variant CSS variables', () => {
     const value = makeEditorState([
       {

--- a/src/renderer/__tests__/render-builtin-node.test.tsx
+++ b/src/renderer/__tests__/render-builtin-node.test.tsx
@@ -81,6 +81,25 @@ describe('renderBuiltinNode', () => {
     expect(html).toContain('<tbody>');
   });
 
+  it('renders table colgroup from colWidths', () => {
+    const html = toHTML({ colWidths: [375, 200], type: 'table' }, ['row']);
+    expect(html).toContain('<colgroup>');
+    expect(html).toContain('<col style="width:375px"/>');
+    expect(html).toContain('<col style="width:200px"/>');
+  });
+
+  it('renders table without colWidths as full width', () => {
+    const html = toHTML({ type: 'table' }, ['row']);
+    expect(html).not.toContain('<colgroup>');
+    expect(html).toContain('width:100%');
+  });
+
+  it('ignores unusable colWidths', () => {
+    const html = toHTML({ colWidths: [0, Number.NaN], type: 'table' }, ['row']);
+    expect(html).not.toContain('<colgroup>');
+    expect(html).toContain('width:100%');
+  });
+
   it('renders tablecell as th with class', () => {
     const html = toHTML({ headerState: 1, type: 'tablecell' }, ['Header']);
     expect(html).toContain('<th');

--- a/src/renderer/engine/render-builtin-node.tsx
+++ b/src/renderer/engine/render-builtin-node.tsx
@@ -54,6 +54,18 @@ function textToSlug(text: string): string {
     .replaceAll(/^-+|-+$/g, '');
 }
 
+// `.editor_table` sets `table-layout: fixed`, so a table without column widths
+// collapses to its minimum width instead of filling the container.
+const FLUID_TABLE_STYLE: CSSProperties = { width: '100%' };
+
+function toTableColWidths(value: unknown): number[] | null {
+  if (!Array.isArray(value) || value.length === 0) {
+    return null;
+  }
+
+  return value.every((width) => Number.isFinite(width) && width > 0) ? (value as number[]) : null;
+}
+
 const DIFF_ROOT_STYLE: CSSProperties = {
   position: 'relative',
 };
@@ -242,9 +254,18 @@ export function renderBuiltinNode(
       );
     }
     case 'table': {
+      const colWidths = toTableColWidths(node.colWidths);
+
       return (
         <div className={getTableWrapperClassName()} key={key}>
-          <table className="editor_table">
+          <table className="editor_table" style={colWidths ? undefined : FLUID_TABLE_STYLE}>
+            {colWidths && (
+              <colgroup>
+                {colWidths.map((width, index) => (
+                  <col key={index} style={{ width }} />
+                ))}
+              </colgroup>
+            )}
             <tbody>{children}</tbody>
           </table>
         </div>


### PR DESCRIPTION
## Problem

`LexicalRenderer` renders every table without a `<colgroup>`, so tables collapse.

Measured in real Chrome, a 2-column table with `colWidths: [375, 375]` inside a 772px container:

| | table width | column widths |
| --- | --- | --- |
| before | 241px | 120 / 120 |
| after | 751px | 375 / 375 |

At that width the cells wrap character-by-character, which makes any table-bearing document unreadable in static output.

## Root cause

The shared table stylesheet sets `table-layout: fixed` (`src/plugins/table/react/style.ts:88`), and that stylesheet is used by both the live editor and the static renderer. Fixed layout needs explicit column widths.

The live editor satisfies it because `@lexical/table`'s `TableNode` emits the colgroup itself — this repo already depends on that, e.g. `useAutoFitPastedTable.ts` reads `:scope > colgroup > col`.

The static renderer does not. `render-builtin-node.tsx`'s `table` case emitted `<div><table><tbody>` and never read `node.colWidths`, even though the table plugin models it end to end (`getColWidths`/`setColWidths`, XML round-trip, `createDefaultTableColWidths`) and it is present in serialized state.

`git log -S colgroup -- src/renderer/` is empty, so this has been missing since `LexicalRenderer` was introduced rather than being a regression.

## Fix

Emit a `<colgroup>` built from `colWidths` so static output matches what the editor produces.

When `colWidths` is absent or unusable, fall back to an inline `width: 100%` on the table. `createDefaultTableColWidths` cannot be used here: it needs a column count, and the renderer has none — `render-tree` passes `node.exportJSON()`, and `ElementNode.exportJSON()` always returns an empty `children` array, so the serialized table reaching the renderer has no rows to count. Matching `@lexical/table`'s own no-`colWidths` behaviour (width-less `<col>` elements) would not help either, since that still collapses under fixed layout. `width: 100%` lets fixed layout distribute columns evenly across the container without needing a count, and cannot render worse than today (measured: 772px, 386 / 386).

The width validity predicate (`Number.isFinite(width) && width > 0`) matches the existing one in `useAutoFitPastedTable.ts`.

## Scope

`LexicalDiff` routes every block through the same `renderBuiltinNode`, so it collapsed identically; this one change covers both renderers. Nothing under `src/renderer/diff/` needed changing — `computeLexicalDiffRows` passes serialized blocks through untouched, so `colWidths` survives into both sides.

## Tests

Five new assertions across `render-builtin-node`, `LexicalRenderer`, and `LexicalDiff`, covering colgroup emission, the no-`colWidths` fallback, rejection of unusable widths, the full serialized round-trip, and both sides of a diff.

Verified in both directions: with the implementation reverted and the tests kept, exactly those 5 fail and all 57 pre-existing tests pass; with the fix applied, 62/62 pass. `tsc --noEmit`, `lint:circular`, and the pre-commit lint-staged chain are clean.