### PR TITLE
✨ feat(image): add preview action

### DIFF
--- a/src/locale/index.ts
+++ b/src/locale/index.ts
@@ -22,6 +22,7 @@ export default {
   },
   image: {
     broken: 'Broken image',
+    preview: 'Preview image',
     replace: 'Replace',
   },
   link: {

--- a/src/plugins/image/react/components/Image.tsx
+++ b/src/plugins/image/react/components/Image.tsx
@@ -1,11 +1,13 @@
-import { Icon } from '@lobehub/ui';
+import { ActionIcon, Icon } from '@lobehub/ui';
+import { Image as AntImage } from 'antd';
 import { cx } from 'antd-style';
 import { COMMAND_PRIORITY_LOW, SELECTION_CHANGE_COMMAND } from 'lexical';
-import { LoaderCircleIcon } from 'lucide-react';
+import { LoaderCircleIcon, ZoomInIcon } from 'lucide-react';
 import React, { memo, Suspense, useCallback, useMemo, useRef, useState } from 'react';
 
 import { useLexicalEditor } from '@/editor-kernel/react/useLexicalEditor';
 import { useLexicalNodeSelection } from '@/editor-kernel/react/useLexicalNodeSelection';
+import { useTranslation } from '@/editor-kernel/react/useTranslation';
 
 import type { BlockImageNode } from '../../node/block-image-node';
 import { $isBlockImageNode } from '../../node/block-image-node';
@@ -35,6 +37,7 @@ const Image = memo<ImageProps>(
   ({ node, className, showScaleInfo = false, handleUpload, onPickFile }) => {
     const [isSelected, setSelected] = useLexicalNodeSelection(node.getKey());
     const [isHovered, setIsHovered] = useState(false);
+    const [previewOpen, setPreviewOpen] = useState(false);
     const [scale, setScale] = useState(1);
     const [size, setSize] = useState({ height: 0, width: 0 });
     const [newWidth, setNewWidth] = useState<number | null>(null);
@@ -43,6 +46,7 @@ const Image = memo<ImageProps>(
     const editorRef = useRef<any>(null);
     const startWidthRef = useRef<number>(0);
     const lastLoadedSrcRef = useRef<string | null>(null);
+    const t = useTranslation();
     const isBlock = useMemo(() => {
       return $isBlockImageNode(node);
     }, [node]);
@@ -132,6 +136,12 @@ const Image = memo<ImageProps>(
     // Mouse leave handler
     const handleMouseLeave = useCallback(() => {
       setIsHovered(false);
+    }, []);
+
+    const handlePreview = useCallback((e: React.MouseEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      setPreviewOpen(true);
     }, []);
 
     const children = useMemo(() => {
@@ -225,6 +235,24 @@ const Image = memo<ImageProps>(
               <Icon icon={LoaderCircleIcon} size={24} spin />
             </div>
           )}
+
+          {(isHovered || isSelected) && node.status === 'uploaded' && (
+            <ActionIcon
+              aria-label={t('image.preview')}
+              glass
+              className={styles.previewAction}
+              icon={ZoomInIcon}
+              onClick={handlePreview}
+              size="small"
+              title={t('image.preview')}
+              variant="filled"
+            />
+          )}
+
+          <AntImage.PreviewGroup
+            items={[node.src]}
+            preview={{ open: previewOpen, onOpenChange: setPreviewOpen }}
+          />
 
           {/* Scale info display */}
           {showScaleInfo && isSelected && scale !== 1 && (

--- a/src/plugins/image/react/components/__tests__/Image.test.tsx
+++ b/src/plugins/image/react/components/__tests__/Image.test.tsx
@@ -17,8 +17,32 @@ const mocks = vi.hoisted(() => {
 
   return {
     editor,
+    isSelected: false,
     resizeHandleProps: [] as ResizeHandleProps[],
+    setSelected: vi.fn(),
   };
+});
+
+vi.mock('@lobehub/ui', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  ActionIcon: ({
+    'aria-label': ariaLabel,
+    onClick,
+  }: {
+    'aria-label'?: string;
+    'onClick'?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  }) => <button aria-label={ariaLabel} type="button" onClick={onClick} />,
+}));
+
+vi.mock('antd', async (importOriginal) => {
+  const original = await importOriginal<typeof import('antd')>();
+  const MockImage = Object.assign(() => null, {
+    PreviewGroup: ({ preview }: { preview?: { open?: boolean } }) => (
+      <div data-preview-open={String(preview?.open)} />
+    ),
+  });
+
+  return { ...original, Image: MockImage };
 });
 
 vi.mock('@/editor-kernel/react/useLexicalEditor', async () => {
@@ -34,7 +58,11 @@ vi.mock('@/editor-kernel/react/useLexicalEditor', async () => {
 });
 
 vi.mock('@/editor-kernel/react/useLexicalNodeSelection', () => ({
-  useLexicalNodeSelection: () => [false, vi.fn(), vi.fn(), false],
+  useLexicalNodeSelection: () => [mocks.isSelected, mocks.setSelected, vi.fn(), false],
+}));
+
+vi.mock('@/editor-kernel/react/useTranslation', () => ({
+  useTranslation: () => (key: string) => key,
 }));
 
 vi.mock('../ImageEditPopover', () => ({
@@ -83,6 +111,7 @@ describe('Image resize', () => {
     host = document.createElement('div');
     document.body.append(host);
     root = createRoot(host);
+    mocks.isSelected = false;
     mocks.resizeHandleProps.length = 0;
     vi.clearAllMocks();
   });
@@ -134,5 +163,38 @@ describe('Image resize', () => {
 
     expect(node.setWidth).toHaveBeenCalledWith(140);
     expect(node.setMaxWidth).toHaveBeenCalledWith(140);
+  });
+
+  it('opens the image preview from the hover action without selecting the node', async () => {
+    const node = {
+      altText: 'test image',
+      getKey: () => 'image-node',
+      getType: () => 'block-image',
+      maxWidth: 200,
+      src: 'https://example.com/image.png',
+      status: 'uploaded',
+      width: 200,
+    };
+
+    await act(async () => {
+      root.render(<Image node={node as any} />);
+    });
+
+    expect(host.querySelector('[aria-label="image.preview"]')).toBeNull();
+
+    const image = host.querySelector<HTMLImageElement>('[data-testid="image"]');
+    await act(async () => {
+      image!.parentElement!.dispatchEvent(new MouseEvent('mouseover', { bubbles: true }));
+    });
+
+    const previewButton = host.querySelector<HTMLButtonElement>('[aria-label="image.preview"]');
+    expect(previewButton).not.toBeNull();
+
+    await act(async () => {
+      previewButton!.click();
+    });
+
+    expect(host.querySelector('[data-preview-open="true"]')).not.toBeNull();
+    expect(mocks.setSelected).not.toHaveBeenCalled();
   });
 });

--- a/src/plugins/image/react/components/style.ts
+++ b/src/plugins/image/react/components/style.ts
@@ -83,6 +83,13 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     color: ${cssVar.colorTextSecondary};
   `,
 
+  previewAction: css`
+    position: absolute;
+    z-index: 10000;
+    inset-block-start: 8px;
+    inset-inline-end: 8px;
+  `,
+
   resizeHandle: css`
     pointer-events: auto;
     cursor: col-resize;

--- a/src/plugins/image/react/components/style.ts
+++ b/src/plugins/image/react/components/style.ts
@@ -88,6 +88,26 @@ export const styles = createStaticStyles(({ css, cssVar }) => ({
     z-index: 10000;
     inset-block-start: 8px;
     inset-inline-end: 8px;
+
+    && {
+      border: 1px solid rgb(255 255 255 / 24%);
+
+      color: rgb(255 255 255 / 96%);
+
+      background: rgb(0 0 0 / 58%);
+      backdrop-filter: saturate(120%) blur(12px);
+      box-shadow: 0 2px 8px rgb(0 0 0 / 36%);
+    }
+
+    &&:hover {
+      color: rgb(255 255 255);
+      background: rgb(0 0 0 / 72%);
+    }
+
+    &&:active {
+      color: rgb(255 255 255);
+      background: rgb(0 0 0 / 80%);
+    }
   `,
 
   resizeHandle: css`

--- a/src/react/EditorProvider/demos/index.tsx
+++ b/src/react/EditorProvider/demos/index.tsx
@@ -10,6 +10,7 @@ const customLocale = {
   },
   image: {
     broken: '图片损坏',
+    preview: '预览图片',
     replace: '替换',
   },
   link: {


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- Show a compact zoom action at the top-right of uploaded image nodes while hovered or selected.
- Keep the icon readable across image content with a high-contrast white icon, dark translucent blurred backdrop, border, and shadow.
- Open the full image preview without triggering image selection or the edit popover.
- Add an accessible label, locale text, and a behavior regression test.

#### 📝 补充信息 | Additional Information

- Focused Vitest: 2/2 passed.
- Type check, package build, Stylelint, circular dependency check, lint-staged, and diff check passed.
- Acceptance: https://app.lobehub.com/acceptance/c84b6926-ca83-4a41-8cb0-ea27f21c9d9f?r=2