### PR TITLE
🐛 fix: release editor resources on root detach

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
 
       - name: Test and coverage
         run: pnpm run test:coverage
+        env:
+          NODE_OPTIONS: --expose-gc
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/src/editor-kernel/__tests__/root-lifecycle.test.ts
+++ b/src/editor-kernel/__tests__/root-lifecycle.test.ts
@@ -77,4 +77,21 @@ describe('editor root lifecycle', () => {
     kernel.setDocument('text', 'reinitialized');
     expect(kernel.getDocument('text')).toBe('reinitialized');
   });
+
+  it('does not attach dragon support for headless editors', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    const kernel = Editor.createEditor().registerPlugins([CommonPlugin]);
+    kernels.push(kernel);
+
+    kernel.initHeadlessEditor();
+
+    expect(addEventListener.mock.calls.filter(([type]) => type === 'message')).toHaveLength(0);
+
+    kernel.destroy();
+
+    expect(removeEventListener.mock.calls.filter(([type]) => type === 'message')).toHaveLength(0);
+    addEventListener.mockRestore();
+    removeEventListener.mockRestore();
+  });
 });

--- a/src/editor-kernel/__tests__/root-lifecycle.test.ts
+++ b/src/editor-kernel/__tests__/root-lifecycle.test.ts
@@ -1,0 +1,80 @@
+import type { EditorConfig } from 'lexical';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+
+import { getKernelFromEditorConfig } from '../utils';
+
+const getKernelFor = (editor: ReturnType<typeof Editor.createEditor>) =>
+  getKernelFromEditorConfig({ theme: editor.getTheme() } as EditorConfig);
+
+describe('editor root lifecycle', () => {
+  const kernels: Array<ReturnType<typeof Editor.createEditor>> = [];
+
+  afterEach(() => {
+    kernels.splice(0).forEach((kernel) => kernel.destroy());
+  });
+
+  it('releases and restores the EditorMap and dragon listener around root detach', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    const kernel = Editor.createEditor().registerPlugins([CommonPlugin]);
+    kernels.push(kernel);
+
+    const firstRoot = document.createElement('div');
+    const secondRoot = document.createElement('div');
+    const lexicalEditor = kernel.setRootElement(firstRoot);
+
+    expect(getKernelFor(kernel)).toBe(kernel);
+    expect(addEventListener.mock.calls.filter(([type]) => type === 'message')).toHaveLength(1);
+
+    kernel.setRootElement(null);
+
+    expect(kernel.getRootElement()).toBeNull();
+    expect(getKernelFor(kernel)).toBeNull();
+    expect(removeEventListener.mock.calls.filter(([type]) => type === 'message')).toHaveLength(1);
+
+    kernel.setRootElement(secondRoot);
+
+    expect(kernel.getLexicalEditor()).toBe(lexicalEditor);
+    expect(kernel.getRootElement()).toBe(secondRoot);
+    expect(getKernelFor(kernel)).toBe(kernel);
+    expect(addEventListener.mock.calls.filter(([type]) => type === 'message')).toHaveLength(2);
+
+    kernel.setRootElement(null);
+    expect(removeEventListener.mock.calls.filter(([type]) => type === 'message')).toHaveLength(2);
+
+    addEventListener.mockRestore();
+    removeEventListener.mockRestore();
+  });
+
+  it('tracks direct Lexical root changes and supports destroy followed by re-init', () => {
+    const kernel = Editor.createEditor().registerPlugins([CommonPlugin]);
+    kernels.push(kernel);
+    const firstRoot = document.createElement('div');
+    const secondRoot = document.createElement('div');
+    const firstLexicalEditor = kernel.setRootElement(firstRoot);
+
+    firstLexicalEditor.setRootElement(null);
+    expect(getKernelFor(kernel)).toBeNull();
+
+    firstLexicalEditor.setRootElement(secondRoot);
+    expect(getKernelFor(kernel)).toBe(kernel);
+    expect(kernel.getLexicalEditor()).toBe(firstLexicalEditor);
+
+    kernel.destroy();
+
+    expect(kernel.getLexicalEditor()).toBeNull();
+    expect(getKernelFor(kernel)).toBeNull();
+
+    const reinitializedEditor = kernel.setRootElement(document.createElement('div'));
+    expect(reinitializedEditor).not.toBe(firstLexicalEditor);
+    expect(kernel.getRootElement()).toBe(reinitializedEditor.getRootElement());
+    expect(kernel.getLexicalEditor()).toBe(reinitializedEditor);
+    expect(getKernelFor(kernel)).toBe(kernel);
+
+    kernel.setDocument('text', 'reinitialized');
+    expect(kernel.getDocument('text')).toBe('reinitialized');
+  });
+});

--- a/src/editor-kernel/kernel.ts
+++ b/src/editor-kernel/kernel.ts
@@ -797,6 +797,14 @@ export class Kernel extends EventEmitter implements IEditorKernel {
     };
   }
 
+  registerRootListener(listener: (rootElement: HTMLElement | null) => void): () => void {
+    if (!this.editor || this.headlessEditor) {
+      return noop;
+    }
+
+    return this.editor.registerRootListener(listener);
+  }
+
   private getEditorId(): string {
     return this.themes[EDITOR_THEME_KEY] as string;
   }

--- a/src/editor-kernel/kernel.ts
+++ b/src/editor-kernel/kernel.ts
@@ -88,6 +88,12 @@ export class Kernel extends EventEmitter implements IEditorKernel {
 
   private historyState = createEmptyHistoryState();
 
+  /**
+   * Root-scoped resources are attached to the Lexical editor's root listener
+   * so direct Lexical setRootElement(null) calls are safe as well.
+   */
+  private unregisterRootLifecycle?: () => void;
+
   private editor?: LexicalEditor;
   private headlessEditor = false;
 
@@ -174,31 +180,65 @@ export class Kernel extends EventEmitter implements IEditorKernel {
   }
 
   destroy() {
-    unregisterEditorKernel(this.themes[EDITOR_THEME_KEY]);
+    const editor = this.editor;
+    const editorId = this.getEditorId();
     this.logger.info(`🗑️ Destroying editor with ${this.pluginsInstances.length} plugins`);
+
+    // Detach first. This invokes every root listener cleanup (including
+    // @lexical/dragon) and releases the EditorMap entry before plugin teardown.
+    if (editor) {
+      try {
+        editor.setRootElement(null);
+      } catch (error) {
+        this.logger.warn('Failed to detach editor root during destroy:', error);
+      }
+    }
+    unregisterEditorKernel(editorId);
+
     try {
-      this.editor?.setEditorState(createEmptyEditorState());
+      editor?.setEditorState(createEmptyEditorState());
     } catch (error) {
       this.logger.warn('Failed to reset editor state during destroy:', error);
     }
-    this.dataTypeMap.clear();
+
+    this.unregisterRootLifecycle?.();
+    this.unregisterRootLifecycle = undefined;
+
+    // Run all plugin cleanups even when one plugin reports an error. The
+    // kernel remains reusable after destroy; callers still receive the first
+    // cleanup error after state has been reset below.
+    let destroyError: unknown;
     this.pluginsInstances.forEach((plugin) => {
-      if (plugin.destroy) {
-        plugin.destroy();
+      try {
+        plugin.destroy?.();
+      } catch (error) {
+        destroyError ??= error;
       }
     });
     this.pluginsInstances = [];
-    this.beforeEditorInitHooks = [];
-    this.nodeTransforms = [];
-    this.rootClassNames.clear();
-    // Clear services to support hot reload
-    this.serviceMap.clear();
-    // Clear decorators to prevent memory leaks
+
+    // Plugin constructors are retained as declarative configuration, while
+    // all constructor-owned runtime registrations are rebuilt on the next
+    // initialization. Resetting these collections also prevents duplicate
+    // Lexical node registrations after destroy() followed by re-attach.
+    this.dataTypeMap.clear();
     this.decorators = {};
-    // Clear themes
-    this.themes = {};
+    this.nodeTransforms = [];
+    this.nodes = [];
+    this.beforeEditorInitHooks = [];
+    this.rootClassNames.clear();
+    this.serviceMap.clear();
+    this.themes = { [EDITOR_THEME_KEY]: generateEditorId() };
+    this.historyState = createEmptyHistoryState();
+    this._commands.clear();
+    this._commandsClean.clear();
+    this.editor = undefined;
     this.headlessEditor = false;
     this.logger.info('✅ Editor destroyed');
+
+    if (destroyError) {
+      throw destroyError;
+    }
   }
 
   getRootElement(): HTMLElement | null {
@@ -208,16 +248,36 @@ export class Kernel extends EventEmitter implements IEditorKernel {
     return this.editor?.getRootElement() || null;
   }
 
-  setRootElement(dom: HTMLElement, editable: boolean = true): LexicalEditor {
+  setRootElement(dom: HTMLElement, editable?: boolean): LexicalEditor;
+  setRootElement(dom: null, editable?: boolean): LexicalEditor | null;
+  setRootElement(dom: HTMLElement | null, editable: boolean = true): LexicalEditor | null {
     // Check if editor is already initialized to prevent re-initialization
     if (this.editor) {
       if (this.headlessEditor) {
+        if (dom === null) {
+          return this.editor;
+        }
         throw new Error('Headless editor cannot be attached to a root element.');
       }
       this.logger.warn('[Editor] Editor is already initialized, updating root element only');
+      if (dom) {
+        // Lexical may invoke root listeners while reconciling the new root;
+        // make the kernel discoverable before that reconciliation starts.
+        registerEditorKernel(this.getEditorId(), this);
+      }
       this.editor.setRootElement(dom);
-      this.applyRootClassNames(dom);
+      if (dom) {
+        this.editor.setEditable(editable);
+        this.applyRootClassNames(dom);
+      }
       return this.editor;
+    }
+
+    if (dom === null) {
+      // useEditor() can be cleaned up even when no descendant ever mounted a
+      // root. There is nothing to detach in that case.
+      unregisterEditorKernel(this.getEditorId());
+      return null;
     }
 
     // Initialize plugins if not already done
@@ -232,7 +292,7 @@ export class Kernel extends EventEmitter implements IEditorKernel {
     this.runBeforeEditorInitLifecycle();
     const resolvedNodes = this.resolveNodesForInitialization();
     this.logger.info(`📝 Creating editor with ${resolvedNodes.length} nodes`);
-    registerEditorKernel(this.themes[EDITOR_THEME_KEY], this);
+    registerEditorKernel(this.getEditorId(), this);
     const editor = (this.editor = createEditor({
       // @ts-expect-error Inject into lexical editor instance
       __kernel: this,
@@ -246,9 +306,9 @@ export class Kernel extends EventEmitter implements IEditorKernel {
       theme: this.themes,
     }));
     this.headlessEditor = false;
+    this.registerRootLifecycle(editor);
     this.editor.setRootElement(dom);
     this.applyRootClassNames(dom);
-    registerEvent(editor, dom);
 
     this.pluginsInstances.forEach((plugin) => {
       plugin.onInit?.(editor);
@@ -296,6 +356,7 @@ export class Kernel extends EventEmitter implements IEditorKernel {
       theme: this.themes,
     }));
     this.headlessEditor = false;
+    this.registerRootLifecycle(editor);
 
     this.pluginsInstances.forEach((plugin) => {
       plugin.onInit?.(editor);
@@ -733,6 +794,36 @@ export class Kernel extends EventEmitter implements IEditorKernel {
       if (currentRootElement) {
         currentRootElement.classList.remove(...classNames);
       }
+    };
+  }
+
+  private getEditorId(): string {
+    return this.themes[EDITOR_THEME_KEY] as string;
+  }
+
+  private registerRootLifecycle(editor: LexicalEditor): void {
+    this.unregisterRootLifecycle?.();
+    let rootEventCleanup: (() => void) | undefined;
+    const clearRootEvent = () => {
+      rootEventCleanup?.();
+      rootEventCleanup = undefined;
+    };
+    const unregisterRootListener = editor.registerRootListener((rootElement) => {
+      clearRootEvent();
+      if (!rootElement) {
+        unregisterEditorKernel(this.getEditorId());
+        return;
+      }
+
+      // Root listeners can be triggered by callers using the Lexical editor
+      // directly, so registration must happen here as well as in the kernel
+      // setRootElement wrapper.
+      registerEditorKernel(this.getEditorId(), this);
+      rootEventCleanup = registerEvent(editor, rootElement);
+    });
+    this.unregisterRootLifecycle = () => {
+      clearRootEvent();
+      unregisterRootListener();
     };
   }
 

--- a/src/plugins/common/plugin/index.ts
+++ b/src/plugins/common/plugin/index.ts
@@ -451,24 +451,26 @@ export const CommonPlugin: IEditorPluginConstructor<CommonPluginOptions> = class
     // Dragon installs a window-level message listener whose closure captures
     // the editor. Tie it to the root lifecycle so Activity can detach the
     // listener while keeping the same editor/plugins alive for reattachment.
-    if (!(editor as LexicalEditor & { _headless?: boolean })._headless) {
-      let dragonCleanup: (() => void) | undefined;
-      const clearDragon = () => {
-        dragonCleanup?.();
-        dragonCleanup = undefined;
-      };
+    let dragonCleanup: (() => void) | undefined;
+    const clearDragon = () => {
+      dragonCleanup?.();
+      dragonCleanup = undefined;
+    };
 
-      this.register(
-        editor.registerRootListener((rootElement) => {
-          clearDragon();
-          if (!rootElement || !CAN_USE_DOM) {
-            return;
-          }
-          dragonCleanup = registerDragonSupport(editor);
-        }),
-      );
-      this.register(clearDragon);
-    }
+    // Kernel root listeners are a no-op for headless editors because headless
+    // Lexical instances do not support registerRootListener. This keeps the
+    // lifecycle independent of Lexical's private `_headless` implementation
+    // detail while still following every DOM root attach/detach.
+    this.register(
+      this.kernel.registerRootListener((rootElement) => {
+        clearDragon();
+        if (!rootElement || !CAN_USE_DOM) {
+          return;
+        }
+        dragonCleanup = registerDragonSupport(editor);
+      }),
+    );
+    this.register(clearDragon);
 
     this.registerClears(
       registerRichText(editor),

--- a/src/plugins/common/plugin/index.ts
+++ b/src/plugins/common/plugin/index.ts
@@ -28,7 +28,6 @@ import {
   TextNode,
 } from 'lexical';
 
-import { noop } from '@/editor-kernel';
 import { INodeHelper } from '@/editor-kernel/inode/helper';
 import { KernelPlugin } from '@/editor-kernel/plugin';
 import { ILitexmlService } from '@/plugins/litexml';
@@ -449,10 +448,31 @@ export const CommonPlugin: IEditorPluginConstructor<CommonPluginOptions> = class
         COMMAND_PRIORITY_CRITICAL,
       ),
     );
+    // Dragon installs a window-level message listener whose closure captures
+    // the editor. Tie it to the root lifecycle so Activity can detach the
+    // listener while keeping the same editor/plugins alive for reattachment.
+    if (!(editor as LexicalEditor & { _headless?: boolean })._headless) {
+      let dragonCleanup: (() => void) | undefined;
+      const clearDragon = () => {
+        dragonCleanup?.();
+        dragonCleanup = undefined;
+      };
+
+      this.register(
+        editor.registerRootListener((rootElement) => {
+          clearDragon();
+          if (!rootElement || !CAN_USE_DOM) {
+            return;
+          }
+          dragonCleanup = registerDragonSupport(editor);
+        }),
+      );
+      this.register(clearDragon);
+    }
+
     this.registerClears(
       registerRichText(editor),
       registerProgressiveSelectAll(editor),
-      CAN_USE_DOM ? registerDragonSupport(editor) : noop,
       registerHistory(editor, this.kernel.getHistoryState(), 300),
       registerBlockBackspace(editor),
       registerRichKeydown(editor, this.kernel, {

--- a/src/plugins/common/react/ReactPlainText.tsx
+++ b/src/plugins/common/react/ReactPlainText.tsx
@@ -168,10 +168,24 @@ const ReactPlainText = memo<ReactPlainTextProps>(
     }, [editor]);
 
     useEffect(() => {
+      // The attach effect above can initialize the kernel during the same
+      // commit. Keep this dependency so a first render that observes no
+      // Lexical editor retries after setRootElement() succeeds. Activity also
+      // re-runs passive effects on reveal, which rebinds this listener after a
+      // reversible root detach.
+      if (!isInitialized) {
+        return;
+      }
+
+      const lexicalEditor = editor.getLexicalEditor();
+      if (!lexicalEditor) {
+        return;
+      }
+
       // Track previous content for onTextChange comparison
       let previousContent: string | undefined;
 
-      return editor.getLexicalEditor()?.registerUpdateListener(({ dirtyElements, dirtyLeaves }) => {
+      return lexicalEditor.registerUpdateListener(({ dirtyElements, dirtyLeaves }) => {
         // Always trigger onChange for any update
         onChange?.(editor);
 
@@ -188,7 +202,7 @@ const ReactPlainText = memo<ReactPlainTextProps>(
           }
         }
       });
-    }, [editor, type, onChange, onTextChange]);
+    }, [editor, isInitialized, type, onChange, onTextChange]);
 
     useEffect(() => {
       if (!isInitialized) return;

--- a/src/plugins/common/react/ReactPlainText.tsx
+++ b/src/plugins/common/react/ReactPlainText.tsx
@@ -110,6 +110,9 @@ const ReactPlainText = memo<ReactPlainTextProps>(
     const {
       props: { type, content, placeholder, lineEmptyPlaceholder },
     } = Children.only(children);
+    const initialDocumentRef = useRef({ content, type });
+    const editableRef = useRef(editable);
+    editableRef.current = editable;
 
     useLayoutEffect(() => {
       editor.registerPlugin(MarkdownPlugin, {
@@ -139,15 +142,32 @@ const ReactPlainText = memo<ReactPlainTextProps>(
 
     useEffect(() => {
       const container = editorContainerRef.current;
-      if (container && !isInitialized) {
-        // Initialize the editor
-        editor.setRootElement(container, editable);
-
-        // Set initial document content only once
-        editor.setDocument(type, content);
-        setIsInitialized(true);
+      if (!container) {
+        return;
       }
 
+      const lexicalEditor = editor.getLexicalEditor();
+      if (!lexicalEditor) {
+        // Initialize the editor
+        editor.setRootElement(container, editableRef.current);
+
+        // Set initial document content only once
+        editor.setDocument(initialDocumentRef.current.type, initialDocumentRef.current.content);
+        setIsInitialized(true);
+      } else if (editor.getRootElement() !== container) {
+        // React Activity cleans up effects while hiding a subtree. Reattach
+        // the existing Lexical editor instead of reinitializing plugins/state.
+        editor.setRootElement(container, editableRef.current);
+      }
+
+      return () => {
+        if (editor.getRootElement() === container) {
+          editor.setRootElement(null);
+        }
+      };
+    }, [editor]);
+
+    useEffect(() => {
       // Track previous content for onTextChange comparison
       let previousContent: string | undefined;
 
@@ -168,14 +188,14 @@ const ReactPlainText = memo<ReactPlainTextProps>(
           }
         }
       });
-    }, [editor, type, content, onChange, onTextChange, isInitialized]);
+    }, [editor, type, onChange, onTextChange]);
 
     useEffect(() => {
       if (!isInitialized) return;
       if (typeof editable === 'boolean') {
         editor.setEditable(editable);
       }
-    }, [isInitialized, editable]);
+    }, [editor, isInitialized, editable]);
 
     useEffect(() => {
       if (editor && onPressEnter) {

--- a/src/plugins/common/react/__tests__/lifecycle.test.tsx
+++ b/src/plugins/common/react/__tests__/lifecycle.test.tsx
@@ -1,11 +1,16 @@
-import { act, Activity, useEffect, useRef } from 'react';
+import { KEY_DOWN_COMMAND } from 'lexical';
+import { act, Activity, StrictMode, useEffect, useRef } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import EditorKernel from '@/editor-kernel';
 import { CommonPlugin } from '@/plugins/common';
+import { IMarkdownShortCutService } from '@/plugins/markdown/service/shortcut';
 import Editor from '@/react/Editor';
 import { useEditor } from '@/react/hooks/useEditor';
 import type { IEditor } from '@/types';
+
+const hasExplicitGC = typeof (globalThis as typeof globalThis & { gc?: unknown }).gc === 'function';
 
 describe('React editor root lifecycle', () => {
   let host: HTMLDivElement | null;
@@ -80,57 +85,202 @@ describe('React editor root lifecycle', () => {
     expect(initialEditor.getDocument('text')).toBe('after show');
   });
 
-  it('allows a hook-owned editor to become collectible after unmount', async () => {
-    let editorRef: WeakRef<IEditor> | undefined;
+  it('rebuilds the React editor runtime after an external destroy before reattach', () => {
+    const externalEditor = EditorKernel.createEditor();
     let mode: 'hidden' | 'visible' = 'visible';
+    const onPressEnter = vi.fn(() => true);
 
-    const HookOwnedEditor = () => {
-      const editor = useEditor();
+    const renderEditor = () =>
+      root!.render(
+        <Activity mode={mode}>
+          <Editor
+            content="initial"
+            editor={externalEditor}
+            onPressEnter={onPressEnter}
+            type="text"
+          />
+        </Activity>,
+      );
+
+    act(renderEditor);
+
+    const firstLexicalEditor = externalEditor.getLexicalEditor();
+    expect(firstLexicalEditor).toBeDefined();
+    expect(externalEditor.getDocument('text')).toBe('initial');
+    expect(externalEditor.requireService(IMarkdownShortCutService)).not.toBeNull();
+
+    externalEditor.destroy();
+    expect(externalEditor.getLexicalEditor()).toBeNull();
+
+    mode = 'hidden';
+    act(renderEditor);
+    mode = 'visible';
+    act(renderEditor);
+
+    const reinitializedLexicalEditor = externalEditor.getLexicalEditor();
+    expect(reinitializedLexicalEditor).toBeDefined();
+    expect(reinitializedLexicalEditor).not.toBe(firstLexicalEditor);
+    expect(externalEditor.getRootElement()).toBeInstanceOf(HTMLElement);
+    expect(externalEditor.getDocument('text')).toBe('initial');
+    expect(externalEditor.requireService(IMarkdownShortCutService)).not.toBeNull();
+    expect(externalEditor.isEditable()).toBe(true);
+
+    expect(
+      externalEditor.dispatchCommand(
+        KEY_DOWN_COMMAND,
+        new KeyboardEvent('keydown', { key: 'Enter' }),
+      ),
+    ).toBe(true);
+    expect(onPressEnter).toHaveBeenCalledTimes(1);
+
+    externalEditor.setDocument('text', 'restored');
+    expect(externalEditor.getDocument('text')).toBe('restored');
+    externalEditor.destroy();
+  });
+
+  it('keeps StrictMode Activity hide/show and duplicate cleanup listener-safe', () => {
+    const addEventListener = vi.spyOn(window, 'addEventListener');
+    const removeEventListener = vi.spyOn(window, 'removeEventListener');
+    let editor: IEditor | undefined;
+    let mode: 'hidden' | 'visible' = 'visible';
+    let editable = true;
+
+    const StrictModeEditor = () => {
+      const nextEditor = useEditor();
+      editor = nextEditor;
+      return <Editor editor={nextEditor} content="initial" editable={editable} type="text" />;
+    };
+
+    const renderEditor = () =>
+      root!.render(
+        <StrictMode>
+          <Activity mode={mode}>
+            <StrictModeEditor />
+          </Activity>
+        </StrictMode>,
+      );
+    const messageAdds = () =>
+      addEventListener.mock.calls.filter(([type]) => type === 'message').length;
+    const messageRemoves = () =>
+      removeEventListener.mock.calls.filter(([type]) => type === 'message').length;
+    const activeDragonListeners = () => messageAdds() - messageRemoves();
+
+    try {
+      act(renderEditor);
+      const initialLexicalEditor = editor?.getLexicalEditor();
+      expect(initialLexicalEditor).toBeDefined();
+      expect(activeDragonListeners()).toBe(1);
+
+      for (let attempt = 0; attempt < 3; attempt += 1) {
+        mode = 'hidden';
+        act(renderEditor);
+        expect(editor?.getRootElement()).toBeNull();
+        expect(activeDragonListeners()).toBe(0);
+
+        editable = attempt % 2 === 0;
+        mode = 'visible';
+        act(renderEditor);
+        expect(editor?.getLexicalEditor()).toBe(initialLexicalEditor);
+        expect(editor?.isEditable()).toBe(editable);
+        expect(activeDragonListeners()).toBe(1);
+      }
+
+      mode = 'hidden';
+      act(renderEditor);
+      expect(() => act(() => root?.unmount())).not.toThrow();
+      root = null;
+      expect(activeDragonListeners()).toBe(0);
+      expect(messageAdds()).toBe(messageRemoves());
+    } finally {
+      if (root) {
+        act(() => root?.unmount());
+        root = null;
+      }
+      addEventListener.mockRestore();
+      removeEventListener.mockRestore();
+    }
+  });
+
+  it('destroys a hook-owned editor when a permanent owner opts into autoDestroy', () => {
+    let editor: IEditor | undefined;
+
+    const PermanentEditor = () => {
+      const nextEditor = useEditor({ autoDestroy: true });
       const containerRef = useRef<HTMLDivElement>(null);
+      editor = nextEditor;
 
       useEffect(() => {
-        editorRef = new WeakRef(editor);
-        editor.registerPlugin(CommonPlugin);
+        nextEditor.registerPlugin(CommonPlugin);
         const container = containerRef.current;
         if (container) {
-          editor.setRootElement(container);
+          nextEditor.setRootElement(container);
         }
-      }, [editor]);
+      }, [nextEditor]);
 
       return <div ref={containerRef} />;
     };
 
-    const renderHookOwnedEditor = () =>
-      root!.render(
-        <Activity mode={mode}>
-          <HookOwnedEditor />
-        </Activity>,
-      );
-
-    act(renderHookOwnedEditor);
-    expect(editorRef?.deref()).toBeDefined();
-
-    mode = 'hidden';
-    act(renderHookOwnedEditor);
-    expect(editorRef?.deref()?.getRootElement()).toBeNull();
+    act(() => root!.render(<PermanentEditor />));
+    expect(editor?.getLexicalEditor()).toBeDefined();
 
     act(() => root?.unmount());
     root = null;
-    host?.remove();
-    host = null;
 
-    const gc = (globalThis as typeof globalThis & { gc?: () => void }).gc;
-    if (!gc) {
-      return;
-    }
-
-    // Do not dereference the WeakRef in the loop condition: the temporary
-    // strong reference would keep the editor alive through the next GC run.
-    for (let attempt = 0; attempt < 10; attempt += 1) {
-      gc();
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-
-    expect(editorRef?.deref()).toBeUndefined();
+    expect(editor?.getLexicalEditor()).toBeNull();
   });
+
+  it.skipIf(!hasExplicitGC)(
+    'allows a hook-owned editor to become collectible after unmount',
+    async () => {
+      let editorRef: WeakRef<IEditor> | undefined;
+      let mode: 'hidden' | 'visible' = 'visible';
+
+      const HookOwnedEditor = () => {
+        const editor = useEditor();
+        const containerRef = useRef<HTMLDivElement>(null);
+
+        useEffect(() => {
+          editorRef = new WeakRef(editor);
+          editor.registerPlugin(CommonPlugin);
+          const container = containerRef.current;
+          if (container) {
+            editor.setRootElement(container);
+          }
+        }, [editor]);
+
+        return <div ref={containerRef} />;
+      };
+
+      const renderHookOwnedEditor = () =>
+        root!.render(
+          <Activity mode={mode}>
+            <HookOwnedEditor />
+          </Activity>,
+        );
+
+      act(renderHookOwnedEditor);
+      expect(editorRef?.deref()).toBeDefined();
+
+      mode = 'hidden';
+      act(renderHookOwnedEditor);
+      expect(editorRef?.deref()?.getRootElement()).toBeNull();
+
+      act(() => root?.unmount());
+      root = null;
+      host?.remove();
+      host = null;
+
+      const gc = (globalThis as typeof globalThis & { gc?: () => void }).gc;
+      expect(gc).toBeTypeOf('function');
+
+      // Do not dereference the WeakRef in the loop condition: the temporary
+      // strong reference would keep the editor alive through the next GC run.
+      for (let attempt = 0; attempt < 10; attempt += 1) {
+        gc!();
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+
+      expect(editorRef?.deref()).toBeUndefined();
+    },
+  );
 });

--- a/src/plugins/common/react/__tests__/lifecycle.test.tsx
+++ b/src/plugins/common/react/__tests__/lifecycle.test.tsx
@@ -1,0 +1,136 @@
+import { act, Activity, useEffect, useRef } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { CommonPlugin } from '@/plugins/common';
+import Editor from '@/react/Editor';
+import { useEditor } from '@/react/hooks/useEditor';
+import type { IEditor } from '@/types';
+
+describe('React editor root lifecycle', () => {
+  let host: HTMLDivElement | null;
+  let root: Root | null;
+
+  beforeEach(() => {
+    (
+      globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+    ).IS_REACT_ACT_ENVIRONMENT = true;
+    host = document.createElement('div');
+    document.body.append(host);
+    root = createRoot(host);
+  });
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount());
+    }
+    host?.remove();
+    root = null;
+    host = null;
+  });
+
+  it('detaches and reattaches one editor through Activity without resetting input state', () => {
+    let editor: IEditor | undefined;
+    let mode: 'hidden' | 'visible' = 'visible';
+
+    const renderEditor = () =>
+      root!.render(
+        <Activity mode={mode}>
+          <Editor
+            content="initial"
+            onInit={(nextEditor) => {
+              editor = nextEditor;
+            }}
+            type="text"
+          />
+        </Activity>,
+      );
+
+    act(renderEditor);
+
+    expect(editor).toBeDefined();
+    const initialEditor = editor!;
+    const initialLexicalEditor = initialEditor.getLexicalEditor();
+    const initialRoot = initialEditor.getRootElement();
+    expect(initialLexicalEditor).toBeDefined();
+    expect(initialRoot).toBeInstanceOf(HTMLElement);
+
+    act(() => {
+      initialEditor.setDocument('text', 'before hide');
+    });
+    const beforeHideState = initialLexicalEditor!.getEditorState();
+
+    mode = 'hidden';
+    act(renderEditor);
+
+    expect(initialEditor.getLexicalEditor()).toBe(initialLexicalEditor);
+    expect(initialEditor.getRootElement()).toBeNull();
+    expect(initialLexicalEditor!.getEditorState()).toBe(beforeHideState);
+
+    mode = 'visible';
+    act(renderEditor);
+
+    expect(editor).toBe(initialEditor);
+    expect(initialEditor.getLexicalEditor()).toBe(initialLexicalEditor);
+    expect(initialEditor.getRootElement()).toBe(initialRoot);
+
+    act(() => {
+      initialEditor.setDocument('text', 'after show');
+    });
+    expect(initialEditor.getDocument('text')).toBe('after show');
+  });
+
+  it('allows a hook-owned editor to become collectible after unmount', async () => {
+    let editorRef: WeakRef<IEditor> | undefined;
+    let mode: 'hidden' | 'visible' = 'visible';
+
+    const HookOwnedEditor = () => {
+      const editor = useEditor();
+      const containerRef = useRef<HTMLDivElement>(null);
+
+      useEffect(() => {
+        editorRef = new WeakRef(editor);
+        editor.registerPlugin(CommonPlugin);
+        const container = containerRef.current;
+        if (container) {
+          editor.setRootElement(container);
+        }
+      }, [editor]);
+
+      return <div ref={containerRef} />;
+    };
+
+    const renderHookOwnedEditor = () =>
+      root!.render(
+        <Activity mode={mode}>
+          <HookOwnedEditor />
+        </Activity>,
+      );
+
+    act(renderHookOwnedEditor);
+    expect(editorRef?.deref()).toBeDefined();
+
+    mode = 'hidden';
+    act(renderHookOwnedEditor);
+    expect(editorRef?.deref()?.getRootElement()).toBeNull();
+
+    act(() => root?.unmount());
+    root = null;
+    host?.remove();
+    host = null;
+
+    const gc = (globalThis as typeof globalThis & { gc?: () => void }).gc;
+    if (!gc) {
+      return;
+    }
+
+    // Do not dereference the WeakRef in the loop condition: the temporary
+    // strong reference would keep the editor alive through the next GC run.
+    for (let attempt = 0; attempt < 10; attempt += 1) {
+      gc();
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+
+    expect(editorRef?.deref()).toBeUndefined();
+  });
+});

--- a/src/plugins/common/react/__tests__/lifecycle.test.tsx
+++ b/src/plugins/common/react/__tests__/lifecycle.test.tsx
@@ -85,6 +85,70 @@ describe('React editor root lifecycle', () => {
     expect(initialEditor.getDocument('text')).toBe('after show');
   });
 
+  it('registers change listeners after attach and after Activity reattach', async () => {
+    const onChange = vi.fn();
+    const onTextChange = vi.fn();
+    let editor: IEditor | undefined;
+    let mode: 'hidden' | 'visible' = 'visible';
+
+    const renderEditor = () =>
+      root!.render(
+        <Activity mode={mode}>
+          <Editor
+            content="initial"
+            debounceWait={0}
+            onChange={onChange}
+            onInit={(nextEditor) => {
+              editor = nextEditor;
+            }}
+            onTextChange={onTextChange}
+            type="text"
+          />
+        </Activity>,
+      );
+    const flushDebouncedCallbacks = () =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, 10);
+      });
+    const setDocumentAndFlush = async (content: string) => {
+      await act(async () => {
+        editor!.setDocument('text', content);
+        await flushDebouncedCallbacks();
+      });
+    };
+
+    act(renderEditor);
+    expect(editor?.getLexicalEditor()).toBeDefined();
+
+    // The initial document is loaded before the update listener is attached.
+    // Clear any delayed initial work so the assertions cover later updates.
+    await act(async () => {
+      await flushDebouncedCallbacks();
+    });
+    onChange.mockClear();
+    onTextChange.mockClear();
+
+    await setDocumentAndFlush('first update');
+    await setDocumentAndFlush('second update');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onTextChange).toHaveBeenCalledTimes(1);
+
+    mode = 'hidden';
+    act(renderEditor);
+    expect(editor?.getRootElement()).toBeNull();
+
+    mode = 'visible';
+    act(renderEditor);
+    expect(editor?.getLexicalEditor()).toBeDefined();
+    onChange.mockClear();
+    onTextChange.mockClear();
+
+    await setDocumentAndFlush('after reattach');
+    await setDocumentAndFlush('after second reattach');
+    expect(onChange).toHaveBeenCalledTimes(2);
+    expect(onTextChange).toHaveBeenCalledTimes(1);
+  });
+
   it('rebuilds the React editor runtime after an external destroy before reattach', () => {
     const externalEditor = EditorKernel.createEditor();
     let mode: 'hidden' | 'visible' = 'visible';

--- a/src/react/Editor/index.mdx
+++ b/src/react/Editor/index.mdx
@@ -370,6 +370,22 @@ The Editor component also provides static methods:
 - `useEditor()`: Hook for creating editor instance
 - `useEditorState(editor)`: Hook for accessing editor state and toolbar methods
 
+### Editor lifecycle
+
+`useEditor()` owns a kernel reference and uses a reversible root detach during React cleanup by default. Detaching releases the editor from the library's global root registry and removes root-scoped DOM and dragon listeners while preserving the Lexical editor state, history, and plugin configuration for a later Activity reattach.
+
+The default detach is compatible with React `<Activity>`: hiding a subtree must not destroy the editor that will be shown again. It also does not promise garbage collection if application code stores the `IEditor` in a provider, zustand store, or another long-lived reference. Remove that reference and unmount the owner when the instance is no longer needed.
+
+Use `useEditor({ autoDestroy: true })` only when the hook owner is guaranteed to be permanently unmounted. `autoDestroy: true` is mutually exclusive with `<Activity>` because Activity runs the same cleanup while hiding a subtree and would destroy the editor before it can be shown again. An editor supplied to another component can also be released explicitly with `editor.destroy()`; after destruction, the React editor lifecycle can initialize a fresh Lexical runtime when it is attached again.
+
+```typescript
+// Activity-safe default: detach while hidden, preserve state, and reattach.
+const editor = useEditor();
+
+// Permanent owner only: destroy all runtime resources on unmount.
+const editor = useEditor({ autoDestroy: true });
+```
+
 ### Modern Usage Example
 
 ```typescript

--- a/src/react/Editor/index.mdx
+++ b/src/react/Editor/index.mdx
@@ -376,6 +376,8 @@ The Editor component also provides static methods:
 
 The default detach is compatible with React `<Activity>`: hiding a subtree must not destroy the editor that will be shown again. It also does not promise garbage collection if application code stores the `IEditor` in a provider, zustand store, or another long-lived reference. Remove that reference and unmount the owner when the instance is no longer needed.
 
+When a tab is actually closed, the application must unmount the editor owner, release any store/provider reference, or call `editor.destroy()`; reversible detach alone cannot reclaim an editor that the application still retains.
+
 Use `useEditor({ autoDestroy: true })` only when the hook owner is guaranteed to be permanently unmounted. `autoDestroy: true` is mutually exclusive with `<Activity>` because Activity runs the same cleanup while hiding a subtree and would destroy the editor before it can be shown again. An editor supplied to another component can also be released explicitly with `editor.destroy()`; after destruction, the React editor lifecycle can initialize a fresh Lexical runtime when it is attached again.
 
 ```typescript

--- a/src/react/hooks/useEditor.ts
+++ b/src/react/hooks/useEditor.ts
@@ -1,8 +1,37 @@
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import Editor from '@/editor-kernel';
 import type { IEditor } from '@/types';
 
-export const useEditor = (): IEditor => {
-  return useMemo(() => Editor.createEditor(), []);
+export interface UseEditorOptions {
+  /**
+   * Destroy the kernel when the owning component is cleaned up.
+   *
+   * The default is false because React Activity also runs effect cleanup while
+   * hiding a subtree. Detaching the root keeps the editor reversible and lets
+   * the same kernel be attached again when the subtree becomes visible.
+   */
+  autoDestroy?: boolean;
+}
+
+export const useEditor = ({ autoDestroy = false }: UseEditorOptions = {}): IEditor => {
+  const editor = useMemo(() => Editor.createEditor(), []);
+
+  useEffect(() => {
+    return () => {
+      if (autoDestroy) {
+        editor.destroy();
+        return;
+      }
+
+      // A hook-owned editor must release root-scoped global references when
+      // its React owner is cleaned up. This is intentionally reversible so
+      // React Activity can attach the same editor again when it is shown.
+      if (editor.getLexicalEditor()) {
+        editor.setRootElement(null);
+      }
+    };
+  }, [autoDestroy, editor]);
+
+  return editor;
 };

--- a/src/react/hooks/useEditor.ts
+++ b/src/react/hooks/useEditor.ts
@@ -10,6 +10,18 @@ export interface UseEditorOptions {
    * The default is false because React Activity also runs effect cleanup while
    * hiding a subtree. Detaching the root keeps the editor reversible and lets
    * the same kernel be attached again when the subtree becomes visible.
+   *
+   * `autoDestroy: true` is mutually exclusive with React Activity: Activity
+   * cannot distinguish a hidden subtree from a permanently unmounted owner,
+   * so its cleanup would destroy the editor during a hide. Use the default
+   * reversible detach with Activity, and call `destroy()` (or unmount the
+   * owner with `autoDestroy`) only when the instance is no longer needed.
+   *
+   * Root detach releases the kernel from the library's global root registry
+   * and DOM/dragon listeners. It does not guarantee garbage collection when
+   * application code keeps the `IEditor` in a store, provider, or other
+   * long-lived reference. Remove that reference, unmount the owner, or use
+   * `autoDestroy: true`/`destroy()` to release the editor's runtime resources.
    */
   autoDestroy?: boolean;
 }

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -14,7 +14,7 @@ export {
   useEditorContent,
 } from './EditorProvider';
 export { default as FloatActions, type FloatActionsProps } from './FloatActions';
-export { useEditor } from './hooks/useEditor';
+export { useEditor,type UseEditorOptions } from './hooks/useEditor';
 export { type EditorState, useEditorState } from './hooks/useEditorState';
 export { default as SendButton, type SendButtonProps } from './SendButton';
 export { ANCHOR_PADDING_CSS_VAR, DEFAULT_BLOCK_ANCHOR_PADDING } from '@/plugins/block/react/style';

--- a/src/react/index.ts
+++ b/src/react/index.ts
@@ -14,7 +14,7 @@ export {
   useEditorContent,
 } from './EditorProvider';
 export { default as FloatActions, type FloatActionsProps } from './FloatActions';
-export { useEditor,type UseEditorOptions } from './hooks/useEditor';
+export { useEditor, type UseEditorOptions } from './hooks/useEditor';
 export { type EditorState, useEditorState } from './hooks/useEditorState';
 export { default as SendButton, type SendButtonProps } from './SendButton';
 export { ANCHOR_PADDING_CSS_VAR, DEFAULT_BLOCK_ANCHOR_PADDING } from '@/plugins/block/react/style';

--- a/src/types/kernel.ts
+++ b/src/types/kernel.ts
@@ -363,6 +363,13 @@ export interface IEditorKernel extends IEditor {
    */
   registerRootClassName(className: string): () => void;
   /**
+   * Register a callback for root attach/detach events.
+   *
+   * Headless kernels return a no-op cleanup because headless Lexical editors
+   * do not support root listeners.
+   */
+  registerRootListener(listener: (rootElement: HTMLElement | null) => void): () => void;
+  /**
    * Register service
    * @param serviceId
    * @param service

--- a/src/types/kernel.ts
+++ b/src/types/kernel.ts
@@ -274,6 +274,7 @@ export interface IEditor {
    * @param dom
    */
   setRootElement(dom: HTMLElement, editable?: boolean): LexicalEditor;
+  setRootElement(dom: null, editable?: boolean): LexicalEditor | null;
 
   /**
    * set editor selection

--- a/src/types/kernel.ts
+++ b/src/types/kernel.ts
@@ -365,8 +365,12 @@ export interface IEditorKernel extends IEditor {
   /**
    * Register a callback for root attach/detach events.
    *
-   * Headless kernels return a no-op cleanup because headless Lexical editors
-   * do not support root listeners.
+   * Call this after the kernel's Lexical editor has been initialized (usually
+   * from plugin onInit). Lexical immediately invokes a newly registered root
+   * listener with the current root, so listeners registered after the initial
+   * setRootElement still receive the first root attach. Headless kernels
+   * return a no-op cleanup because headless Lexical editors do not support
+   * root listeners.
    */
   registerRootListener(listener: (rootElement: HTMLElement | null) => void): () => void;
   /**


### PR DESCRIPTION
## Summary

- release the kernel registry, dragon message listener, and root-scoped DOM listeners when an editor root detaches
- preserve the Lexical editor, editor state, history, and plugin instances across React Activity hide/show cycles
- make `destroy()` reusable by clearing the stale Lexical editor reference and rebuilding plugin runtime state on the next initialization
- guarantee `onChange` and `onTextChange` listeners are registered after initial attach and rebound after Activity reveal
- document the lifecycle contract for detached roots, external store references, permanent owner unmount, and explicit destruction

## Lifecycle contract

- Detach releases library-owned global references (`EditorMap`, dragon, and root DOM listeners), but intentionally preserves the editor runtime for Activity reattachment.
- The library cannot collect an editor that application code still retains in a provider, zustand store, or another long-lived reference.
- Closing a tab must unmount the editor owner, release its store/provider reference, or explicitly call `destroy()`; reversible detach is not a substitute for application ownership cleanup.
- `autoDestroy: true` is explicitly incompatible with React `<Activity>` because Activity runs effect cleanup while hiding.

This is the library-side fix only; it does not include or automatically replace the application workaround from lobehub/lobehub#18954.

## Validation

- exposed-GC lifecycle and renderer regressions: 6 files, 58 tests passed after rebasing onto master
- React coverage includes initial and post-Activity `onChange`/`onTextChange`, external `destroy()` followed by reattach, Common/Markdown runtime restoration, commands, editability, Strict Mode, repeated hide/show, duplicate cleanup, and dragon listener balance
- production root-attachment scan: `ReactPlainText` is the single React root owner; kernel/direct Lexical calls remain covered by root listeners
- `pnpm type-check`
- `pnpm build`
- targeted ESLint
- `git diff --check`

The branch is rebased onto master after the standalone renderer Motion fix from #206; the obsolete test-only Motion wrapper is no longer part of this PR.

The Test CI coverage step sets `NODE_OPTIONS=--expose-gc`, so the GC contract runs in CI rather than silently passing.

Closes #204.