### PR TITLE
🐛 fix: self-provide motion context in LexicalRenderer

### DIFF
--- a/src/renderer/LexicalRenderer.tsx
+++ b/src/renderer/LexicalRenderer.tsx
@@ -1,6 +1,8 @@
 import { createHeadlessEditor } from '@lexical/headless';
+import { MotionComponent, MotionProvider } from '@lobehub/ui';
 import { $getRoot } from 'lexical';
-import { createElement, type ReactElement, type ReactNode, useMemo } from 'react';
+import { motion } from 'motion/react';
+import { createElement, type ReactElement, type ReactNode, use, useMemo } from 'react';
 
 import { renderNode } from './engine/render-tree';
 import { rendererNodes } from './nodes';
@@ -18,6 +20,11 @@ export function LexicalRenderer({
   style,
   variant,
 }: LexicalRendererProps): ReactElement {
+  // @lobehub/ui >= 5.38 requires a motion component from context (ConfigProvider
+  // or MotionProvider). The renderer must stay self-contained for standalone
+  // SSR/static usage, so provide a default only when the host has not already
+  // supplied one — a host-provided (possibly lazy) motion component wins.
+  const inheritedMotion = use(MotionComponent);
   const content = useMemo(() => {
     const nodes = extraNodes ? [...rendererNodes, ...extraNodes] : rendererNodes;
     const registry = createDefaultRenderers();
@@ -50,7 +57,7 @@ export function LexicalRenderer({
 
   // Mirrors Editor's structure: outer div (flex column + CSS vars + theme rules)
   // → inner div (block, allows normal margin collapse like contentEditable)
-  return createElement(
+  const tree = createElement(
     Tag,
     {
       className: getRendererClassName(className),
@@ -58,4 +65,6 @@ export function LexicalRenderer({
     },
     createElement('div', null, content),
   );
+
+  return inheritedMotion ? tree : createElement(MotionProvider, { children: tree, motion });
 }

--- a/src/renderer/__tests__/LexicalRenderer.test.tsx
+++ b/src/renderer/__tests__/LexicalRenderer.test.tsx
@@ -1,4 +1,6 @@
+import { MotionProvider } from '@lobehub/ui';
 import { DecoratorNode, type LexicalUpdateJSON, type SerializedEditorState } from 'lexical';
+import { motion } from 'motion/react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it } from 'vitest';
 
@@ -194,6 +196,26 @@ describe('LexicalRenderer', () => {
     const html = toHTML(value);
     expect(html).toContain('<pre');
     expect(html).toContain('JavaScript');
+    expect(html).toContain('const x = 1;');
+  });
+
+  it('respects a host-provided motion context', () => {
+    const value = makeEditorState([
+      {
+        code: 'const x = 1;',
+        codeTheme: '',
+        language: 'javascript',
+        options: { indentWithTabs: false, lineNumbers: false, tabSize: 2 },
+        type: 'code',
+        version: 1,
+      },
+    ]);
+
+    const html = renderToStaticMarkup(
+      <MotionProvider motion={motion}>
+        <LexicalRenderer value={value} />
+      </MotionProvider>,
+    );
     expect(html).toContain('const x = 1;');
   });
 


### PR DESCRIPTION
## Problem

`@lobehub/ui >= 5.38` requires a motion component from context (`ConfigProvider`/`MotionProvider`) before rendering `Button`, and `ConfigProvider` itself only forwards a host-supplied `motion` prop. The standalone SSR renderer (`@lobehub/editor/renderer`) renders `Highlighter`/`Mermaid` (which include copy buttons), so any document containing a code block crashes with:

```
Error: Please wrap your app with <ConfigProvider> (or <MotionProvider>) and pass the motion component
```

This is the source of the 4 known `LexicalRenderer.test.tsx` baseline failures on `master`, and it affects real SSR consumers, not just tests.

## Fix

`LexicalRenderer` now reads `MotionComponent` context and only provides a default full `motion` implementation when the host has not already supplied one — a host-provided (possibly lazy `m`) motion component always wins. The renderer stays self-contained for standalone SSR/static usage with zero new dependencies (`motion ^12` is already a peer dependency).

## Validation

- `LexicalRenderer.test.tsx`: 4 previously failing tests now pass; added a regression test for the host-provided context path (18/18)
- full `src/renderer` suite: 67/67
- `tsc --noEmit` ✅

## Note

PR #203 can rebase onto this to restore a fully green CI baseline.