### PR TITLE
🐛 fix(auto-complete): stabilize IME input and simplify preview lifecycle

### DIFF
--- a/src/plugins/auto-complete/node/placeholderNode.ts
+++ b/src/plugins/auto-complete/node/placeholderNode.ts
@@ -18,6 +18,11 @@ export class PlaceholderNode extends ElementNode {
   }
 
   createDOM(config: EditorConfig): HTMLElement {
+    // This transient wrapper can contain block DOM to preserve multiline
+    // layout without splitting the host paragraph. Such nesting is not a
+    // portable HTML serialization; `display: inline-block` would not change
+    // the HTML content model. Acceptance reparses the source Markdown instead
+    // of reusing this wrapper's innerHTML.
     const element = document.createElement('span');
     element.contentEditable = 'false';
     element.setAttribute('data-auto-complete-preview', 'true');
@@ -60,6 +65,7 @@ export class PlaceholderNode extends ElementNode {
   }
 }
 
+/** Legacy node type kept for deserializing previews saved by older versions. */
 export class PlaceholderBlockNode extends ElementNode {
   static getType(): string {
     return 'PlaceholderBlock';

--- a/src/plugins/auto-complete/node/placeholderNode.ts
+++ b/src/plugins/auto-complete/node/placeholderNode.ts
@@ -19,7 +19,8 @@ export class PlaceholderNode extends ElementNode {
 
   createDOM(config: EditorConfig): HTMLElement {
     const element = document.createElement('span');
-
+    element.contentEditable = 'false';
+    element.setAttribute('data-auto-complete-preview', 'true');
     element.setAttribute('data-lexical-key', this.getKey());
     addClassNamesToElement(element, config.theme.placeholderInline);
     return element;

--- a/src/plugins/auto-complete/plugin/context.ts
+++ b/src/plugins/auto-complete/plugin/context.ts
@@ -30,6 +30,7 @@ export function $readCompletionContext(): CompletionContext | null {
     else input += text;
   };
   const visit = (node: LexicalNode) => {
+    // Exclude current previews and the legacy block format from request text.
     if (node instanceof PlaceholderNode || node instanceof PlaceholderBlockNode) return;
     if (node.is(target)) {
       if ($isElementNode(node)) {

--- a/src/plugins/auto-complete/plugin/context.ts
+++ b/src/plugins/auto-complete/plugin/context.ts
@@ -1,0 +1,64 @@
+import type { LexicalNode } from 'lexical';
+import { $getSelection, $isElementNode, $isRangeSelection, $isTextNode } from 'lexical';
+
+import { PlaceholderBlockNode, PlaceholderNode } from '../node/placeholderNode';
+
+export interface CompletionContext {
+  afterText: string;
+  fingerprint: string;
+  input: string;
+  selectionType: string;
+}
+
+/** Read the paragraph around the caret, excluding unaccepted preview content. */
+export function $readCompletionContext(): CompletionContext | null {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return null;
+  const { anchor } = selection;
+  const target = anchor.getNode();
+  let block = target;
+  while ($isTextNode(block) || block.isInline()) {
+    const parent = block.getParent();
+    if (!parent) break;
+    block = parent;
+  }
+  let input = '';
+  let afterText = '';
+  let after = false;
+  const append = (text: string) => {
+    if (after) afterText += text;
+    else input += text;
+  };
+  const visit = (node: LexicalNode) => {
+    if (node instanceof PlaceholderNode || node instanceof PlaceholderBlockNode) return;
+    if (node.is(target)) {
+      if ($isElementNode(node)) {
+        node.getChildren().forEach((child, index) => {
+          after = index >= anchor.offset;
+          visit(child);
+        });
+      } else {
+        input += node.getTextContent().slice(0, anchor.offset);
+        afterText += node.getTextContent().slice(anchor.offset);
+      }
+      after = true;
+    } else if ($isElementNode(node)) {
+      node.getChildren().forEach(visit);
+    } else append(node.getTextContent());
+  };
+  visit(block);
+  return {
+    afterText,
+    fingerprint: JSON.stringify([
+      anchor.key,
+      anchor.offset,
+      anchor.type,
+      input,
+      afterText,
+      selection.format,
+      selection.style,
+    ]),
+    input,
+    selectionType: target.getType(),
+  };
+}

--- a/src/plugins/auto-complete/plugin/ime-safari.test.ts
+++ b/src/plugins/auto-complete/plugin/ime-safari.test.ts
@@ -1,0 +1,99 @@
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical';
+import { expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+import { MarkdownPlugin } from '@/plugins/markdown/plugin';
+
+import { AutoCompletePlugin } from './index';
+
+// Lexical selects its native composition path at module initialization.
+vi.hoisted(() => {
+  Object.defineProperty(navigator, 'platform', { configurable: true, value: 'MacIntel' });
+  Object.defineProperty(navigator, 'userAgent', {
+    configurable: true,
+    value: 'Mozilla/5.0 (Macintosh) AppleWebKit/605.1.15 Version/17.6 Safari/605.1.15',
+  });
+  InputEvent.prototype.getTargetRanges = () => [];
+  Range.prototype.getBoundingClientRect = () => new DOMRect();
+});
+
+it('waits for Safari insertFromComposition even if the settlement timer fires first', async () => {
+  vi.useFakeTimers();
+  const kernel = Editor.createEditor().registerPlugins([CommonPlugin, MarkdownPlugin]);
+  const request = vi.fn(async () => '建议');
+  kernel.registerPlugin(AutoCompletePlugin, { delay: 10, onAutoComplete: request });
+  const errors: unknown[] = [];
+  kernel.on('error', (error) => errors.push(error));
+  const root = document.createElement('div');
+  root.setAttribute('contenteditable', 'true');
+  root.tabIndex = 0;
+  document.body.append(root);
+  const editor = kernel.setRootElement(root);
+  root.focus();
+  try {
+    editor.update(
+      () => {
+        const text = $createTextNode('前后');
+        $getRoot().clear().append($createParagraphNode().append(text));
+        text.select(1, 1);
+      },
+      { discrete: true },
+    );
+    await vi.advanceTimersByTimeAsync(10);
+    const preview = root.querySelector<HTMLElement>('[data-auto-complete-preview]')!;
+    expect(preview).not.toBeNull();
+    root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    expect(preview.style.display).toBe('none');
+    const dom = root.querySelector('[data-lexical-text]')!.firstChild!;
+    dom.nodeValue = '前a';
+    document.getSelection()!.setBaseAndExtent(dom, 2, dom, 2);
+    root.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        data: 'a',
+        inputType: 'insertCompositionText',
+        isComposing: true,
+      }),
+    );
+    await Promise.resolve();
+    // Safari's composing DOM may include Lexical's non-breaking-space marker.
+    const preeditDOM = dom.nodeValue;
+    expect(preeditDOM).toContain('前a');
+    root.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '啊' }));
+
+    // The timer is allowed to run, but Lexical still owns the native preedit
+    // range. Neither the preview nor its neighboring text may be removed.
+    await vi.advanceTimersByTimeAsync(50);
+    expect(editor.isComposing()).toBe(true);
+    expect(preview.isConnected).toBe(true);
+    expect(dom.nodeValue).toBe(preeditDOM);
+    expect(request).toHaveBeenCalledTimes(1);
+
+    const range = document.createRange();
+    range.setStart(dom, 1);
+    range.setEnd(dom, 2);
+    const commit = new InputEvent('beforeinput', {
+      bubbles: true,
+      cancelable: true,
+      data: '啊',
+      inputType: 'insertFromComposition',
+    });
+    commit.getTargetRanges = () => [range];
+    root.dispatchEvent(commit);
+    // Lexical handles this beforeinput itself and prevents native insertion.
+    expect(commit.defaultPrevented).toBe(true);
+    expect(editor.isComposing()).toBe(false);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(preview.isConnected).toBe(false);
+    expect(editor.getEditorState().read(() => $getRoot().getTextContent())).toBe('前啊后');
+    await vi.advanceTimersByTimeAsync(10);
+    expect(request).toHaveBeenCalledTimes(2);
+    expect(root.querySelector<HTMLElement>('[data-auto-complete-preview]')!.style.display).toBe('');
+    expect(errors).toEqual([]);
+  } finally {
+    kernel.destroy();
+    root.remove();
+    vi.useRealTimers();
+  }
+});

--- a/src/plugins/auto-complete/plugin/ime.test.ts
+++ b/src/plugins/auto-complete/plugin/ime.test.ts
@@ -1,0 +1,111 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+} from 'lexical';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+import { MarkdownPlugin } from '@/plugins/markdown/plugin';
+
+import { AutoCompletePlugin } from './index';
+
+vi.hoisted(() => {
+  Object.defineProperty(navigator, 'platform', { configurable: true, value: 'MacIntel' });
+  Object.defineProperty(navigator, 'userAgent', {
+    configurable: true,
+    value: 'Mozilla/5.0 (Macintosh) AppleWebKit/537.36 Chrome/140.0.0.0 Safari/537.36',
+  });
+  InputEvent.prototype.getTargetRanges = () => [];
+  Range.prototype.getBoundingClientRect = () => new DOMRect();
+});
+
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+afterEach(() => vi.useRealTimers());
+
+describe('native composition replacement', () => {
+  it.each([false, true])('replaces preedit a with 啊 (autocomplete %s)', async (enabled) => {
+    vi.useFakeTimers();
+    const kernel = Editor.createEditor().registerPlugins([CommonPlugin, MarkdownPlugin]);
+    if (enabled)
+      kernel.registerPlugin(AutoCompletePlugin, { delay: 10, onAutoComplete: async () => '建议' });
+    const root = document.createElement('div');
+    root.contentEditable = 'true';
+    root.setAttribute('contenteditable', 'true');
+    root.tabIndex = 0;
+    document.body.append(root);
+    const editor = kernel.setRootElement(root);
+    const errors: unknown[] = [];
+    kernel.on('error', (error) => errors.push(error));
+    root.focus();
+    editor.update(
+      () => {
+        const text = $createTextNode('前后');
+        $getRoot().clear().append($createParagraphNode().append(text));
+        text.select(1, 1);
+      },
+      { discrete: true },
+    );
+    await flush();
+    await vi.advanceTimersByTimeAsync(10);
+    await flush();
+
+    const suffix = root.querySelector('[data-lexical-text]')!.textContent!.slice(1);
+    const setDOMText = (value: string, offset: number) => {
+      const dom = root.querySelector('[data-lexical-text]')!.firstChild!;
+      dom.nodeValue = value;
+      document.getSelection()!.setBaseAndExtent(dom, offset, dom, offset);
+    };
+    try {
+      root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true, data: '' }));
+      await flush();
+      root.dispatchEvent(
+        new InputEvent('beforeinput', {
+          bubbles: true,
+          data: 'a',
+          inputType: 'insertCompositionText',
+          isComposing: true,
+        }),
+      );
+      setDOMText('前a' + suffix, 2);
+      root.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: 'a',
+          inputType: 'insertCompositionText',
+          isComposing: true,
+        }),
+      );
+      await flush();
+      setDOMText('前啊' + suffix, 2);
+      root.dispatchEvent(
+        new InputEvent('input', {
+          bubbles: true,
+          data: '啊',
+          inputType: 'insertCompositionText',
+          isComposing: true,
+        }),
+      );
+      root.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '啊' }));
+      await flush();
+      await vi.advanceTimersByTimeAsync(0);
+      editor.getEditorState().read(() => {
+        expect($getRoot().getTextContent()).toBe('前啊后');
+        const selection = $getSelection();
+        expect($isRangeSelection(selection) && selection.isCollapsed()).toBe(true);
+      });
+      expect(errors).toEqual([]);
+    } finally {
+      kernel.destroy();
+      root.remove();
+    }
+  });
+});

--- a/src/plugins/auto-complete/plugin/index.test.ts
+++ b/src/plugins/auto-complete/plugin/index.test.ts
@@ -1,0 +1,268 @@
+import {
+  $createParagraphNode,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $isElementNode,
+  $isTextNode,
+  KEY_ESCAPE_COMMAND,
+  KEY_TAB_COMMAND,
+  UNDO_COMMAND,
+} from 'lexical';
+import type { LexicalEditor } from 'lexical';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+import { MarkdownPlugin } from '@/plugins/markdown/plugin';
+
+import { AutoCompletePlugin } from './index';
+
+const fixtures: Array<{
+  kernel: ReturnType<typeof Editor.createEditor>;
+  root: HTMLElement;
+  errors: unknown[];
+}> = [];
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+};
+beforeAll(() => {
+  Range.prototype.getBoundingClientRect = () => new DOMRect();
+});
+afterEach(() => {
+  for (const fixture of fixtures.splice(0)) {
+    fixture.kernel.destroy();
+    fixture.root.remove();
+    expect(fixture.errors).toEqual([]);
+  }
+  vi.useRealTimers();
+});
+
+function setup(onAutoComplete = vi.fn(async () => '建议')) {
+  vi.useFakeTimers();
+  const kernel = Editor.createEditor().registerPlugins([CommonPlugin, MarkdownPlugin]);
+  const accepted = vi.fn();
+  const rejected = vi.fn();
+  kernel.registerPlugin(AutoCompletePlugin, {
+    delay: 25,
+    onAutoComplete,
+    onSuggestionAccepted: accepted,
+    onSuggestionRejected: rejected,
+  });
+  const root = document.createElement('div');
+  root.setAttribute('contenteditable', 'true');
+  root.tabIndex = 0;
+  document.body.append(root);
+  const errors: unknown[] = [];
+  kernel.on('error', (error) => errors.push(error));
+  const editor = kernel.setRootElement(root);
+  fixtures.push({ kernel, root, errors });
+  root.focus();
+  editor.update(
+    () => {
+      const text = $createTextNode('abcdef');
+      $getRoot().clear().append($createParagraphNode().append(text));
+      text.select(3, 3);
+    },
+    { discrete: true },
+  );
+  return { kernel, editor, root, accepted, rejected, onAutoComplete };
+}
+
+const text = (editor: LexicalEditor) =>
+  editor.getEditorState().read(() => $getRoot().getTextContent());
+const preview = (root: HTMLElement) =>
+  root.querySelector<HTMLElement>('[data-auto-complete-preview]');
+const show = async () => {
+  await vi.advanceTimersByTimeAsync(25);
+  await flush();
+};
+
+function nativeInput(root: HTMLElement, value: string, offset: number, data: string) {
+  const selection = document.getSelection()!;
+  const dom = selection.anchorNode!;
+  expect(dom.nodeType).toBe(Node.TEXT_NODE);
+  root.dispatchEvent(
+    new InputEvent('beforeinput', {
+      bubbles: true,
+      inputType: 'insertCompositionText',
+      data,
+      isComposing: true,
+    }),
+  );
+  dom.nodeValue = value;
+  selection.setBaseAndExtent(dom, offset, dom, offset);
+  root.dispatchEvent(
+    new InputEvent('input', {
+      bubbles: true,
+      inputType: 'insertCompositionText',
+      data,
+      isComposing: true,
+    }),
+  );
+}
+
+describe('AutoCompletePlugin', () => {
+  it('shows a multiline preview without splitting the original paragraph, then cancels it cleanly', async () => {
+    const f = setup(vi.fn(async () => '建议\n\n第二段'));
+    await show();
+    const node = preview(f.root)!;
+    expect(node).not.toBeNull();
+    expect(node.contentEditable).toBe('false');
+    expect(node.textContent).toBe('建议第二段');
+    expect(node.querySelector('p')).not.toBeNull();
+    expect(f.editor.getEditorState().read(() => $getRoot().getChildrenSize())).toBe(1);
+    const event = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true });
+    f.editor.dispatchCommand(KEY_ESCAPE_COMMAND, event);
+    await flush();
+    expect(event.defaultPrevented).toBe(true);
+    expect(preview(f.root)).toBeNull();
+    expect(text(f.editor)).toBe('abcdef');
+    expect(f.editor.getEditorState().read(() => $getRoot().getChildrenSize())).toBe(1);
+    expect(f.rejected).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ reason: 'esc' }));
+    await show();
+    expect(f.onAutoComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides preview synchronously, preserves preedit replacement, and resumes after composition', async () => {
+    const f = setup();
+    await show();
+    const node = preview(f.root)!;
+    f.root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    expect(node.style.display).toBe('none');
+    expect(node.isConnected).toBe(true);
+    await flush();
+    nativeInput(f.root, 'abca', 4, 'a');
+    await flush();
+    expect(node.isConnected).toBe(true);
+    nativeInput(f.root, 'abc啊', 4, '啊');
+    f.root.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '啊' }));
+    await flush();
+    expect(node.style.display).toBe('none');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(preview(f.root)).toBeNull();
+    expect(text(f.editor)).toBe('abc啊def');
+    expect(f.rejected).toHaveBeenCalledTimes(1);
+    await show();
+    expect(f.onAutoComplete).toHaveBeenCalledTimes(2);
+    expect(preview(f.root)!.style.display).toBe('');
+  });
+
+  it('lets the IME own Tab and Escape, including a cancelled composition', async () => {
+    const f = setup();
+    await show();
+    f.root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    const tab = new KeyboardEvent('keydown', { key: 'Tab', isComposing: true, cancelable: true });
+    const esc = new KeyboardEvent('keydown', {
+      key: 'Escape',
+      isComposing: true,
+      cancelable: true,
+    });
+    f.editor.dispatchCommand(KEY_TAB_COMMAND, tab);
+    f.editor.dispatchCommand(KEY_ESCAPE_COMMAND, esc);
+    expect(tab.defaultPrevented).toBe(false);
+    expect(esc.defaultPrevented).toBe(false);
+    expect(f.accepted).not.toHaveBeenCalled();
+    f.root.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '' }));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(text(f.editor)).toBe('abcdef');
+  });
+
+  it('accepts once and undo removes only the accepted suggestion', async () => {
+    const f = setup();
+    await show();
+    f.editor.dispatchCommand(
+      KEY_TAB_COMMAND,
+      new KeyboardEvent('keydown', { key: 'Tab', cancelable: true }),
+    );
+    await flush();
+    expect(text(f.editor)).toBe('abc建议def');
+    expect(preview(f.root)).toBeNull();
+    expect(f.accepted).toHaveBeenCalledTimes(1);
+    expect(f.rejected).not.toHaveBeenCalled();
+    f.editor.dispatchCommand(UNDO_COMMAND, undefined);
+    await flush();
+    expect(text(f.editor)).toBe('abcdef');
+    expect(preview(f.root)).toBeNull();
+  });
+
+  it('discards a late response after the paragraph changes at the same caret position', async () => {
+    let resolve!: (value: string) => void;
+    const f = setup(
+      vi.fn(
+        () =>
+          new Promise<string>((done) => {
+            resolve = done;
+          }),
+      ),
+    );
+    await show();
+    f.editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) throw new Error('missing selection');
+      const paragraph = $getRoot().getFirstChildOrThrow();
+      if (!$isElementNode(paragraph)) throw new Error('missing paragraph');
+      const node = paragraph.getFirstChildOrThrow();
+      if (!$isTextNode(node)) throw new Error('missing text');
+      node.setTextContent('xyzdef');
+    });
+    await flush();
+    resolve('过期');
+    await flush();
+    expect(preview(f.root)).toBeNull();
+    expect(text(f.editor)).toBe('xyzdef');
+  });
+
+  it('aborts a pending request on blur', async () => {
+    let resolve!: (value: string) => void;
+    const f = setup(
+      vi.fn(
+        () =>
+          new Promise<string>((done) => {
+            resolve = done;
+          }),
+      ),
+    );
+    await show();
+    f.root.blur();
+    resolve('过期');
+    await flush();
+    expect(preview(f.root)).toBeNull();
+    expect(text(f.editor)).toBe('abcdef');
+  });
+
+  it('does not restart requests when composition ends outside the editor', async () => {
+    const f = setup();
+    f.root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    f.root.blur();
+    f.root.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '' }));
+    await vi.advanceTimersByTimeAsync(100);
+    expect(f.onAutoComplete).not.toHaveBeenCalled();
+  });
+
+  it('cleans up a hidden preview on detach and cancels deferred work on destroy', async () => {
+    const f = setup();
+    await show();
+    f.root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    f.editor.setRootElement(null);
+    await flush();
+    // Read the serialized model while detached: Lexical refreshes the root's
+    // cached text on reconciliation when the DOM is attached again.
+    expect(f.editor.getEditorState().toJSON().root.children).toEqual([
+      expect.objectContaining({ children: [expect.objectContaining({ text: 'abcdef' })] }),
+    ]);
+    f.editor.setRootElement(f.root);
+    expect(text(f.editor)).toBe('abcdef');
+    f.root.focus();
+    await show();
+    expect(preview(f.root)!.style.display).toBe('');
+    f.root.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }));
+    f.root.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true, data: '' }));
+    f.kernel.destroy();
+    await vi.advanceTimersByTimeAsync(100);
+    expect(preview(f.root)).toBeNull();
+  });
+});

--- a/src/plugins/auto-complete/plugin/index.test.ts
+++ b/src/plugins/auto-complete/plugin/index.test.ts
@@ -189,6 +189,87 @@ describe('AutoCompletePlugin', () => {
     expect(preview(f.root)).toBeNull();
   });
 
+  it('normalizes split text after repeated preview cancellation', async () => {
+    const f = setup();
+    for (let attempt = 0; attempt < 8; attempt++) {
+      f.editor.update(
+        () => {
+          const paragraph = $getRoot().getFirstChildOrThrow();
+          if (!$isElementNode(paragraph)) throw new Error('missing paragraph');
+          const node = paragraph.getFirstChildOrThrow();
+          if (!$isTextNode(node)) throw new Error('missing text');
+          const offset = 2 + (attempt % 2);
+          node.select(offset, offset);
+        },
+        { discrete: true },
+      );
+      await show();
+      expect(preview(f.root)).not.toBeNull();
+      f.editor.dispatchCommand(KEY_ESCAPE_COMMAND, new KeyboardEvent('keydown', { key: 'Escape' }));
+      await flush();
+      f.editor.getEditorState().read(() => {
+        const paragraph = $getRoot().getFirstChildOrThrow();
+        if (!$isElementNode(paragraph)) throw new Error('missing paragraph');
+        expect(paragraph.getChildrenSize()).toBe(1);
+        expect(paragraph.getTextContent()).toBe('abcdef');
+      });
+    }
+  });
+
+  it('invalidates a preview when typing immediately after the response resolves', async () => {
+    let resolve!: (value: string) => void;
+    const f = setup(
+      vi.fn(
+        () =>
+          new Promise<string>((done) => {
+            resolve = done;
+          }),
+      ),
+    );
+    await show();
+    resolve('建议');
+    // Run the response continuation, but not the pending Lexical commit.
+    await Promise.resolve();
+    f.editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) throw new Error('missing selection');
+      selection.insertText('x');
+    });
+    await flush();
+    expect(preview(f.root)).toBeNull();
+    expect(text(f.editor)).toBe('abcxdef');
+    expect(f.rejected).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ reason: 'typing' }),
+    );
+  });
+
+  it('keeps pending user updates separate from a response and schedules for the new text', async () => {
+    let resolve!: (value: string) => void;
+    const f = setup(
+      vi.fn(
+        () =>
+          new Promise<string>((done) => {
+            resolve = done;
+          }),
+      ),
+    );
+    await show();
+    // The response continuation is queued first; the user update is executed
+    // before it, with its commit queued after it.
+    resolve('过期');
+    f.editor.update(() => {
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) throw new Error('missing selection');
+      selection.insertText('x');
+    });
+    await flush();
+    expect(preview(f.root)).toBeNull();
+    expect(text(f.editor)).toBe('abcxdef');
+    await show();
+    expect(f.onAutoComplete).toHaveBeenCalledTimes(2);
+    expect(f.onAutoComplete.mock.calls[1]).toEqual([expect.objectContaining({ input: 'abcx' })]);
+  });
+
   it('discards a late response after the paragraph changes at the same caret position', async () => {
     let resolve!: (value: string) => void;
     const f = setup(

--- a/src/plugins/auto-complete/plugin/index.ts
+++ b/src/plugins/auto-complete/plugin/index.ts
@@ -47,7 +47,11 @@ export interface AutoCompletePluginOptions {
     suggestionId: string;
     visibleMs: number;
   }) => void;
-  theme?: { placeholderBlock?: string; placeholderInline?: string };
+  theme?: {
+    /** Kept for rendering PlaceholderBlock nodes from older serialized documents. */
+    placeholderBlock?: string;
+    placeholderInline?: string;
+  };
 }
 
 type Phase = 'idle' | 'waiting' | 'requesting' | 'visible' | 'composing' | 'settling' | 'destroyed';
@@ -85,6 +89,7 @@ export const AutoCompletePlugin: IEditorPluginConstructor<AutoCompletePluginOpti
     public config?: AutoCompletePluginOptions,
   ) {
     super();
+    // New previews use PlaceholderNode; keep the old block type deserializable.
     kernel.registerNodes([PlaceholderNode, PlaceholderBlockNode]);
     if (config?.theme) kernel.registerThemes(config.theme);
   }
@@ -212,8 +217,10 @@ export const AutoCompletePlugin: IEditorPluginConstructor<AutoCompletePluginOpti
 
   private scheduleSettlement(): void {
     this.cancelSettlement();
-    // Allow the final native input event AND its Lexical commit to finish.
-    // A microtask inside compositionend can run before the browser finishes.
+    // Yield past the current native event, but do not treat a timer as proof
+    // that composition finished. Safari may commit insertFromComposition in
+    // a later task: isComposing() gates removal, and the update listener
+    // re-arms settlement when Lexical finally releases its composition key.
     this.settleTimer = setTimeout(() => {
       this.settleTimer = null;
       if (this.phase !== 'settling' || this.editor?.isComposing()) return;
@@ -281,6 +288,9 @@ export const AutoCompletePlugin: IEditorPluginConstructor<AutoCompletePluginOpti
 
   private showPreview(markdown: string, id: string, context: CompletionContext): void {
     const editor = this.editor!;
+    // Flush earlier user updates with their own tags before starting a preview
+    // transaction. `discrete` below also prevents later input joining this one.
+    if (editor.read($readCompletionContext)?.fingerprint !== context.fingerprint) return;
     editor.update(
       () => {
         if (
@@ -317,7 +327,7 @@ export const AutoCompletePlugin: IEditorPluginConstructor<AutoCompletePluginOpti
         };
         this.phase = 'visible';
       },
-      { tag: [PREVIEW_TAG, HISTORIC_TAG] },
+      { discrete: true, tag: [PREVIEW_TAG, HISTORIC_TAG] },
     );
   }
 

--- a/src/plugins/auto-complete/plugin/index.ts
+++ b/src/plugins/auto-complete/plugin/index.ts
@@ -1,26 +1,30 @@
-import type { BaseSelection, LexicalEditor } from 'lexical';
+import type { LexicalEditor } from 'lexical';
 import {
+  $getNodeByKey,
+  $getRoot,
   $getSelection,
+  $isElementNode,
   $isRangeSelection,
-  $nodesOfType,
   $setSelection,
-  COMMAND_PRIORITY_CRITICAL,
   COMMAND_PRIORITY_HIGH,
   HISTORIC_TAG,
-  KEY_ARROW_LEFT_COMMAND,
-  KEY_ARROW_RIGHT_COMMAND,
+  HISTORY_PUSH_TAG,
   KEY_ESCAPE_COMMAND,
   KEY_TAB_COMMAND,
 } from 'lexical';
 
 import { KernelPlugin } from '@/editor-kernel/plugin';
 import { IMarkdownShortCutService } from '@/plugins/markdown';
+import { $generateNodesFromSerializedNodes } from '@/plugins/markdown/utils';
 import type { IEditor, IEditorKernel, IEditorPlugin, IEditorPluginConstructor } from '@/types';
 import { createDebugLogger } from '@/utils/debug';
 
-import { PlaceholderBlockNode, PlaceholderNode } from '../node/placeholderNode';
-
-const AUTO_COMPLETE_GUARD_LIMIT = 50_000;
+import {
+  $createPlaceholderNode,
+  PlaceholderBlockNode,
+  PlaceholderNode,
+} from '../node/placeholderNode';
+import { $readCompletionContext, type CompletionContext } from './context';
 
 export interface AutoCompletePluginOptions {
   /** Delay in milliseconds before triggering auto-complete (default: 1000ms) */
@@ -43,608 +47,380 @@ export interface AutoCompletePluginOptions {
     suggestionId: string;
     visibleMs: number;
   }) => void;
-  theme?: {
-    placeholderBlock?: string;
-    placeholderInline?: string;
-  };
+  theme?: { placeholderBlock?: string; placeholderInline?: string };
 }
+
+type Phase = 'idle' | 'waiting' | 'requesting' | 'visible' | 'composing' | 'settling' | 'destroyed';
+type RejectReason = Parameters<
+  NonNullable<AutoCompletePluginOptions['onSuggestionRejected']>
+>[0]['reason'];
+type Preview = {
+  context: CompletionContext;
+  id: string;
+  key: string;
+  markdown: string;
+  rejected: boolean;
+  shownAt: number;
+};
+const PREVIEW_TAG = 'auto-complete:preview';
 
 export const AutoCompletePlugin: IEditorPluginConstructor<AutoCompletePluginOptions> = class
   extends KernelPlugin
   implements IEditorPlugin<AutoCompletePluginOptions>
 {
   static pluginName = 'AutoCompletePlugin';
-
   private logger = createDebugLogger('plugin', 'auto-complete');
-  private lastCursorPosition: { key: string; offset: number; type: string } | null = null;
-  private cursorStableTimer: number | null = null;
-  private abortController: AbortController | null = null;
-  private delay: number;
-  private currentSuggestion: string | null = null;
-  private currentSuggestionId: string | null = null;
-  private suggestionIdCounter = 0;
-  private suggestionRequestIdCounter = 0;
-  private activeSuggestionRequestId: number | null = null;
-  private suggestionShownAt = 0;
-  private placeholderAnchorPosition: { key: string; offset: number; type: string } | null = null;
-  private placeholderSelectionSnapshot: BaseSelection | null = null;
+  private phase: Phase = 'idle';
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private settleTimer: ReturnType<typeof setTimeout> | null = null;
+  private request: AbortController | null = null;
+  private preview: Preview | null = null;
+  private lastContext: string | null = null;
+  private suggestionCounter = 0;
+  private editor: LexicalEditor | null = null;
   private markdownService: IMarkdownShortCutService | null = null;
-  private skipNextTextContentListener = false;
 
   constructor(
     protected kernel: IEditorKernel,
     public config?: AutoCompletePluginOptions,
   ) {
     super();
-    this.delay = config?.delay ?? 1000;
-
     kernel.registerNodes([PlaceholderNode, PlaceholderBlockNode]);
-
-    if (config?.theme) {
-      kernel.registerThemes(config?.theme);
-    }
+    if (config?.theme) kernel.registerThemes(config.theme);
   }
 
   onInit(editor: LexicalEditor): void {
+    this.editor = editor;
     this.markdownService = this.kernel.requireService(IMarkdownShortCutService);
+    if (!this.markdownService) return;
 
-    if (!this.markdownService) {
-      this.logger.error('❌ MarkdownShortCutService is required for AutoCompletePlugin');
-      return;
-    }
-
-    const handleBlur = () => {
-      if (this.currentSuggestion) {
-        this.rejectSuggestion('blur');
-        this.clearPlaceholderNodes(editor, { restoreSelection: false });
-      }
+    // Observe native composition without dispatching an extra Lexical update.
+    // Only the browser/Lexical owns preedit text and its replacement range.
+    const startComposition = () => this.suspend();
+    const endComposition = () => {
+      this.phase = 'settling';
+      this.scheduleSettlement();
     };
-
+    const blur = () => this.dismiss('blur');
+    const focus = () => {
+      this.lastContext = null;
+      this.schedule();
+    };
     this.register(
-      editor.registerUpdateListener(({ editorState }) => {
-        editorState.read(() => {
-          if (editor.isComposing()) {
-            this.clearTimer();
-            if (this.currentSuggestion) {
-              this.rejectSuggestion('other');
-              this.clearPlaceholderNodes(editor, { restoreSelection: false });
-            }
-            return;
-          }
-          const selection = $getSelection();
-
-          if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
-            this.clearTimer();
-            if (this.currentSuggestion) {
-              this.rejectSuggestion('other');
-              this.clearPlaceholderNodes(editor, { restoreSelection: false });
-            }
-            return;
-          }
-
-          const currentPosition = {
-            key: selection.anchor.key,
-            offset: selection.anchor.offset,
-            type: selection.anchor.type,
-          };
-
-          // If cursor moved, clear any active placeholder and restart the stable timer
-          if (this.hasPositionChanged(currentPosition)) {
-            this.clearTimer();
-            if (this.currentSuggestion) {
-              this.rejectSuggestion('cursor-move');
-              this.clearPlaceholderNodes(editor, { restoreSelection: false });
-            }
-
-            this.abortController = new AbortController();
-            this.cursorStableTimer = window.setTimeout(() => {
-              this.handleCursorStable(editor, currentPosition);
-            }, this.delay);
-          }
-        });
+      editor.registerRootListener((root, previous) => {
+        previous?.removeEventListener('compositionstart', startComposition, true);
+        previous?.removeEventListener('compositionend', endComposition, true);
+        previous?.removeEventListener('blur', blur);
+        previous?.removeEventListener('focus', focus);
+        if (previous) {
+          this.cancelRequest();
+          this.cancelSettlement();
+          this.lastContext = null;
+          if (this.phase !== 'destroyed') this.phase = 'idle';
+          this.removePreview();
+        }
+        root?.addEventListener('compositionstart', startComposition, true);
+        root?.addEventListener('compositionend', endComposition, true);
+        root?.addEventListener('blur', blur);
+        root?.addEventListener('focus', focus);
+        if (root && !previous) {
+          // A detached editor has no DOM reconciliation to refresh root text
+          // after removing its transient preview. Reconcile on reattachment.
+          editor.update(() => $getRoot().markDirty(), { discrete: true, tag: PREVIEW_TAG });
+        }
       }),
     );
 
-    // Register Tab key handler to apply suggestion
+    // One update listener owns invalidation. Preview updates never retrigger it.
+    this.register(
+      editor.registerUpdateListener(({ editorState, prevEditorState, tags }) => {
+        if (this.phase === 'destroyed' || tags.has(PREVIEW_TAG)) return;
+        if (editor.isComposing()) {
+          this.suspend();
+          return;
+        }
+        if (this.phase === 'composing' || this.phase === 'settling') {
+          this.phase = 'settling';
+          this.scheduleSettlement();
+          return;
+        }
+        const context = editorState.read($readCompletionContext);
+        if (this.preview) {
+          if (context?.fingerprint === this.preview.context.fingerprint) return;
+          const previous = prevEditorState.read($readCompletionContext);
+          const textChanged =
+            context?.input !== previous?.input || context?.afterText !== previous?.afterText;
+          this.dismiss(textChanged ? 'typing' : 'cursor-move', true);
+        } else this.schedule();
+      }),
+    );
+
     this.register(
       editor.registerCommand(
         KEY_TAB_COMMAND,
         (event) => {
-          if (this.currentSuggestion) {
-            event?.preventDefault();
-            this.applySuggestion(editor);
-            return true;
-          }
-          return false;
+          if (event?.isComposing || event?.shiftKey || !this.canAccept()) return false;
+          event?.preventDefault();
+          this.accept();
+          return true;
         },
         COMMAND_PRIORITY_HIGH,
       ),
     );
-
-    this.register(
-      editor.registerCommand(
-        KEY_ARROW_LEFT_COMMAND,
-        () => {
-          if (this.currentSuggestion) {
-            this.rejectSuggestion('cursor-move');
-            this.clearPlaceholderNodes(editor, { restoreSelection: false });
-            return false;
-          }
-          return false;
-        },
-        COMMAND_PRIORITY_CRITICAL,
-      ),
-    );
-
-    this.register(
-      editor.registerCommand(
-        KEY_ARROW_RIGHT_COMMAND,
-        () => {
-          if (this.currentSuggestion) {
-            this.rejectSuggestion('cursor-move');
-            this.clearPlaceholderNodes(editor, { restoreSelection: false });
-            return false;
-          }
-          return false;
-        },
-        COMMAND_PRIORITY_CRITICAL,
-      ),
-    );
-
     this.register(
       editor.registerCommand(
         KEY_ESCAPE_COMMAND,
         (event) => {
-          if (this.currentSuggestion) {
-            event?.preventDefault();
-            this.rejectSuggestion('esc');
-            this.clearPlaceholderNodes(editor);
-            return true;
-          }
-          return false;
+          if (event?.isComposing || !this.canAccept()) return false;
+          event?.preventDefault();
+          this.dismiss('esc');
+          return true;
         },
-        COMMAND_PRIORITY_CRITICAL,
+        COMMAND_PRIORITY_HIGH,
       ),
     );
+  }
 
-    // Register text content listener to clear placeholder on any other input
-    this.register(
-      editor.registerTextContentListener(() => {
-        if (this.skipNextTextContentListener) {
-          this.skipNextTextContentListener = false;
+  private focused(): boolean {
+    const root = this.editor?.getRootElement();
+    return !!root && root.contains(root.ownerDocument.activeElement);
+  }
+
+  private cancelRequest(): void {
+    if (this.timer !== null) clearTimeout(this.timer);
+    this.timer = null;
+    this.request?.abort();
+    this.request = null;
+  }
+
+  private cancelSettlement(): void {
+    if (this.settleTimer !== null) clearTimeout(this.settleTimer);
+    this.settleTimer = null;
+  }
+
+  private suspend(): void {
+    if (this.phase === 'destroyed') return;
+    this.phase = 'composing';
+    this.lastContext = null;
+    this.cancelRequest();
+    this.cancelSettlement();
+    if (this.preview) {
+      this.editor?.getElementByKey(this.preview.key)?.style.setProperty('display', 'none');
+      this.reportRejection('other');
+    }
+  }
+
+  private scheduleSettlement(): void {
+    this.cancelSettlement();
+    // Allow the final native input event AND its Lexical commit to finish.
+    // A microtask inside compositionend can run before the browser finishes.
+    this.settleTimer = setTimeout(() => {
+      this.settleTimer = null;
+      if (this.phase !== 'settling' || this.editor?.isComposing()) return;
+      this.removePreview(() => {
+        if (this.phase !== 'settling') return;
+        this.phase = 'idle';
+        this.schedule();
+      });
+    }, 0);
+  }
+
+  private schedule(): void {
+    if (
+      !this.editor ||
+      !this.focused() ||
+      this.editor.isComposing() ||
+      this.phase === 'composing' ||
+      this.phase === 'settling' ||
+      this.phase === 'destroyed' ||
+      this.preview
+    )
+      return;
+    const context = this.editor.getEditorState().read($readCompletionContext);
+    if (context?.fingerprint === this.lastContext) return;
+    this.cancelRequest();
+    this.lastContext = context?.fingerprint ?? null;
+    this.phase = context ? 'waiting' : 'idle';
+    if (!context || !this.config?.onAutoComplete) return;
+    this.timer = setTimeout(() => {
+      this.timer = null;
+      void this.fetchSuggestion(context);
+    }, this.config.delay ?? 1000);
+  }
+
+  private async fetchSuggestion(context: CompletionContext): Promise<void> {
+    if (!this.editor || !this.focused() || this.phase !== 'waiting') return;
+    if (
+      this.editor.getEditorState().read($readCompletionContext)?.fingerprint !== context.fingerprint
+    )
+      return;
+    const controller = new AbortController();
+    this.request = controller;
+    this.phase = 'requesting';
+    const id = `acp${++this.suggestionCounter}`;
+    try {
+      const markdown = await this.config?.onAutoComplete?.({
+        abortSignal: controller.signal,
+        afterText: context.afterText,
+        editor: this.kernel as IEditor,
+        input: context.input,
+        selectionType: context.selectionType,
+        suggestionId: id,
+      });
+      if (this.request !== controller || controller.signal.aborted || !this.focused()) return;
+      this.request = null;
+      this.phase = 'idle';
+      if (markdown) this.showPreview(markdown, id, context);
+    } catch (error) {
+      if (this.request !== controller) return;
+      this.request = null;
+      this.phase = 'idle';
+      this.logger.warn('Auto-complete request failed:', error);
+    }
+  }
+
+  private showPreview(markdown: string, id: string, context: CompletionContext): void {
+    const editor = this.editor!;
+    editor.update(
+      () => {
+        if (
+          this.phase !== 'idle' ||
+          editor.isComposing() ||
+          !this.focused() ||
+          $readCompletionContext()?.fingerprint !== context.fingerprint
+        )
           return;
-        }
-
-        if (this.currentSuggestion) {
-          this.rejectSuggestion('typing');
-          this.clearPlaceholderNodes(editor, { restoreSelection: false });
-        }
-      }),
+        const selection = $getSelection();
+        if (!$isRangeSelection(selection)) return;
+        const parsed = this.markdownService!.parseMarkdownToLexical(markdown);
+        const children = $generateNodesFromSerializedNodes(parsed.children);
+        if (!children.length) return;
+        const node = $createPlaceholderNode();
+        const [first, ...rest] = children;
+        // Keep the entire preview inside ONE inline wrapper. Its block children
+        // take visual space without splitting the surrounding document paragraph.
+        if ($isElementNode(first) && first.getType() === 'paragraph')
+          node.append(...first.getChildren());
+        else node.append(first);
+        node.append(...rest);
+        const caret = selection.clone();
+        selection.insertNodes([node]);
+        $setSelection(caret);
+        const actualContext = $readCompletionContext();
+        this.preview = {
+          context: actualContext ?? context,
+          id,
+          key: node.getKey(),
+          markdown,
+          rejected: false,
+          shownAt: Date.now(),
+        };
+        this.phase = 'visible';
+      },
+      { tag: [PREVIEW_TAG, HISTORIC_TAG] },
     );
-
-    this.register(
-      editor.registerRootListener((rootElement, prevRootElement) => {
-        prevRootElement?.removeEventListener('blur', handleBlur);
-        rootElement?.addEventListener('blur', handleBlur);
-      }),
-    );
   }
 
-  private createSuggestionId(): string {
-    this.suggestionIdCounter += 1;
-    if (this.suggestionIdCounter > Number.MAX_SAFE_INTEGER) {
-      this.suggestionIdCounter = 1;
-    }
-    return `acp${this.suggestionIdCounter}`;
-  }
-
-  private createSuggestionRequestId(): number {
-    this.suggestionRequestIdCounter += 1;
-    if (this.suggestionRequestIdCounter > Number.MAX_SAFE_INTEGER) {
-      this.suggestionRequestIdCounter = 1;
-    }
-    return this.suggestionRequestIdCounter;
-  }
-
-  private isActiveSuggestionRequest(requestId: number, abortSignal: AbortSignal): boolean {
-    return this.activeSuggestionRequestId === requestId && !abortSignal.aborted;
-  }
-
-  private rejectSuggestion(reason: 'cursor-move' | 'typing' | 'esc' | 'blur' | 'other'): void {
-    if (this.currentSuggestion && this.currentSuggestionId) {
+  private reportRejection(reason: RejectReason): void {
+    const preview = this.preview;
+    if (!preview || preview.rejected) return;
+    preview.rejected = true;
+    try {
       this.config?.onSuggestionRejected?.({
         reason,
-        suggestionId: this.currentSuggestionId,
-        visibleMs: Date.now() - this.suggestionShownAt,
+        suggestionId: preview.id,
+        visibleMs: Date.now() - preview.shownAt,
       });
+    } catch (error) {
+      this.logger.warn('Auto-complete rejection callback failed:', error);
     }
-    this.currentSuggestion = null;
-    this.currentSuggestionId = null;
-    this.suggestionShownAt = 0;
   }
 
-  private hasPositionChanged(currentPosition: {
-    key: string;
-    offset: number;
-    type: string;
-  }): boolean {
-    if (!this.lastCursorPosition) {
-      return true;
-    }
+  private dismiss(reason: RejectReason, restart = false): void {
+    this.cancelRequest();
+    this.reportRejection(reason);
+    if (this.phase === 'composing' || this.phase === 'settling' || this.editor?.isComposing())
+      return;
+    this.phase = 'idle';
+    this.removePreview(() => {
+      if (restart) {
+        this.lastContext = null;
+        this.schedule();
+      }
+    });
+  }
 
+  private removePreview(done?: () => void): void {
+    const preview = this.preview;
+    if (!preview || !this.editor) {
+      done?.();
+      return;
+    }
+    let removed = false;
+    this.editor.update(
+      () => {
+        if (this.editor!.isComposing() || this.phase === 'composing') {
+          this.suspend();
+          return;
+        }
+        $getNodeByKey(preview.key)?.remove();
+        if (this.preview === preview) this.preview = null;
+        removed = true;
+      },
+      {
+        discrete: true,
+        onUpdate: () => {
+          if (removed) done?.();
+        },
+        tag: [PREVIEW_TAG, HISTORIC_TAG],
+      },
+    );
+  }
+
+  private canAccept(): boolean {
     return (
-      this.lastCursorPosition.key !== currentPosition.key ||
-      this.lastCursorPosition.offset !== currentPosition.offset ||
-      this.lastCursorPosition.type !== currentPosition.type
+      this.phase === 'visible' &&
+      !!this.preview &&
+      !this.editor!.isComposing() &&
+      $readCompletionContext()?.fingerprint === this.preview.context.fingerprint
     );
   }
 
-  private clearTimer(): void {
-    this.abortController?.abort('use cancel');
-    this.activeSuggestionRequestId = null;
-    if (this.cursorStableTimer) {
-      clearTimeout(this.cursorStableTimer);
-      this.cursorStableTimer = null;
-    }
-  }
-
-  private handleCursorStable(
-    editor: LexicalEditor,
-    position: { key: string; offset: number; type: string },
-  ): void {
-    editor.getEditorState().read(() => {
-      if (editor.isComposing()) {
-        this.clearTimer();
-        if (this.currentSuggestion) {
-          this.rejectSuggestion('other');
-          this.clearPlaceholderNodes(editor, { restoreSelection: false });
-        }
-        return;
-      }
-      if (!this.abortController || this.abortController.signal.aborted) {
-        return;
-      }
-      const selection = $getSelection();
-
-      if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
-        return;
-      }
-
-      // Verify cursor is still at the same position
-      const currentPosition = {
-        key: selection.anchor.key,
-        offset: selection.anchor.offset,
-        type: selection.anchor.type,
-      };
-
-      if (!this.isSamePosition(position, currentPosition)) {
-        return;
-      }
-
-      // Avoid duplicate triggers for the same position
-      if (this.lastCursorPosition && this.isSamePosition(position, this.lastCursorPosition)) {
-        return;
-      }
-
-      this.lastCursorPosition = currentPosition;
-
-      // Get context around cursor for auto-complete
-      const anchorNode = selection.anchor.getNode();
-      const textRet = this.getTextBeforeCursor(selection);
-      const selectionType = anchorNode.getType();
-
-      // Trigger auto-complete callback if provided
-      if (this.config?.onAutoComplete) {
-        const suggestionId = this.createSuggestionId();
-        const requestId = this.createSuggestionRequestId();
-        const abortSignal = this.abortController!.signal;
-        this.activeSuggestionRequestId = requestId;
-        this.config
-          .onAutoComplete({
-            abortSignal,
-            afterText: textRet.textAfter,
-            editor: this.kernel as any,
-            input: textRet.textBefore,
-            selectionType,
-            suggestionId,
-          })
-          .then((result) => {
-            if (!this.isActiveSuggestionRequest(requestId, abortSignal)) {
-              return;
-            }
-
-            let currentSelection: any = null;
-            editor.getEditorState().read(() => {
-              currentSelection = $getSelection();
-            });
-
-            if (editor.isComposing()) {
-              this.rejectSuggestion('other');
-              this.clearPlaceholderNodes(editor, { restoreSelection: false });
-              return;
-            }
-
-            if (
-              !currentSelection ||
-              !$isRangeSelection(currentSelection) ||
-              !currentSelection.isCollapsed()
-            ) {
-              this.rejectSuggestion('other');
-              this.clearPlaceholderNodes(editor, { restoreSelection: false });
-              return;
-            }
-
-            const newPosition = {
-              key: currentSelection.anchor.key,
-              offset: currentSelection.anchor.offset,
-              type: currentSelection.anchor.type,
-            };
-
-            if (!this.isSamePosition(currentPosition, newPosition)) {
-              this.rejectSuggestion('cursor-move');
-              this.clearPlaceholderNodes(editor, { restoreSelection: false });
-              return;
-            }
-
-            if (result) {
-              this.currentSuggestion = result;
-              this.currentSuggestionId = suggestionId;
-              this.suggestionShownAt = Date.now();
-              this.placeholderAnchorPosition = currentPosition;
-              this.showPlaceholderNodes(editor, result);
-              this.logger.debug('🔍 Auto-complete triggered:', {
-                afterText: textRet.textAfter,
-                input: textRet.textBefore,
-                position: currentPosition,
-                result,
-                selectionType,
-              });
-            } else {
-              this.clearPlaceholderNodes(editor, { restoreSelection: false });
-            }
-          });
-      }
-    });
-  }
-
-  private getTextBeforeCursor(selection: any): {
-    textAfter: string;
-    textBefore: string;
-  } {
-    const anchorNode = selection.anchor.getNode();
-    const anchorOffset = selection.anchor.offset;
-
-    // Find the paragraph or root container
-    let paragraphNode = anchorNode;
-    let parentTraversalCount = 0;
-    while (paragraphNode && paragraphNode.isInline()) {
-      parentTraversalCount++;
-      if (parentTraversalCount > AUTO_COMPLETE_GUARD_LIMIT) {
-        throw new Error(`getTextBeforeCursor: parent traversal > ${AUTO_COMPLETE_GUARD_LIMIT}`);
-      }
-      const parent = paragraphNode.getParent();
-      if (!parent) break;
-      paragraphNode = parent;
-    }
-
-    if (!paragraphNode) {
-      return { textAfter: '', textBefore: '' };
-    }
-
-    this.logger.debug('🔍 Paragraph Node Type:', paragraphNode, anchorNode);
-
-    let founded = false;
-    let recursionDepth = 0;
-
-    // Collect all text before cursor in the paragraph
-    const collectTextBeforeCursor = (
-      node: any,
-      targetNode: any,
-      targetOffset: number,
-    ): { text: string; textAfter: string } => {
-      recursionDepth++;
-      if (recursionDepth > AUTO_COMPLETE_GUARD_LIMIT) {
-        throw new Error(`collectTextBeforeCursor: recursion depth > ${AUTO_COMPLETE_GUARD_LIMIT}`);
-      }
-
-      if (node === targetNode) {
-        founded = true;
-        // We've reached the target node, get text up to the cursor position
-        if (node.getTextContent) {
-          const nodeText = node.getTextContent();
-          return {
-            text: nodeText.slice(0, targetOffset),
-            textAfter: nodeText.slice(targetOffset),
-          };
-        }
-        return { text: '', textAfter: '' };
-      }
-
-      let collectedText = '';
-      let collectedTextAfter = '';
-
-      // If this is a text node, collect all its text
-      if (node.getTextContent && node.getType() === 'text') {
-        if (founded) {
-          collectedTextAfter += node.getTextContent();
-        } else {
-          collectedText += node.getTextContent();
-        }
-      }
-
-      // Recursively check children
-      if (node.getChildren) {
-        const children = node.getChildren();
-        for (const child of children) {
-          const result = collectTextBeforeCursor(child, targetNode, targetOffset);
-          collectedTextAfter += result.textAfter;
-          collectedText += result.text;
-        }
-      }
-
-      return { text: collectedText, textAfter: collectedTextAfter };
-    };
-
-    const result = collectTextBeforeCursor(paragraphNode, anchorNode, anchorOffset);
-    return {
-      textAfter: result.textAfter,
-      textBefore: result.text,
-    };
-  }
-
-  private showPlaceholderNodes(editor: LexicalEditor, suggestion: string): void {
-    this.skipNextTextContentListener = true;
-
-    editor.update(
+  private accept(): void {
+    const preview = this.preview!;
+    this.cancelRequest();
+    this.phase = 'idle';
+    this.preview = null;
+    this.editor!.update(
       () => {
+        $getNodeByKey(preview.key)?.remove();
         const selection = $getSelection();
-        if (!$isRangeSelection(selection) || !selection.isCollapsed()) {
-          this.logger.warn('⚠️ No valid selection for placeholder');
-          return;
-        }
-        if (!this.markdownService) {
-          this.logger.warn('⚠️ No valid markdown service for placeholder');
-          return;
-        }
-
-        // Always clear existing placeholder nodes before inserting a new suggestion
-        // to avoid duplicated/stacked placeholder text.
-        for (const node of $nodesOfType(PlaceholderNode)) {
-          node.remove();
-        }
-        for (const node of $nodesOfType(PlaceholderBlockNode)) {
-          node.remove();
-        }
-
-        const nodes = this.markdownService.parseMarkdownToLexical(suggestion);
-
-        if (nodes.children[0]) {
-          const firstChild = nodes.children[0];
-          // @ts-expect-error not error
-          const oldChildren = firstChild.children;
-          // @ts-expect-error not error
-          firstChild.children = [
-            {
-              children: oldChildren,
-              type: 'PlaceholderInline',
-            },
-          ];
-        }
-
-        for (let i = 1; i < nodes.children.length; i++) {
-          const child = nodes.children[i];
-          nodes.children[i] = {
-            // @ts-expect-error not error
-            children: [child],
-            type: 'PlaceholderBlock',
-          };
-        }
-
-        const saveSel = selection.clone();
-        this.placeholderSelectionSnapshot = saveSel;
-        this.markdownService.insertIRootNode(editor, nodes, selection);
-
-        $setSelection(saveSel);
+        if (!$isRangeSelection(selection) || !selection.isCollapsed()) return;
+        const parsed = this.markdownService!.parseMarkdownToLexical(preview.markdown);
+        this.markdownService!.insertIRootNode(this.editor!, parsed, selection);
       },
-      { tag: HISTORIC_TAG },
-    );
-  }
-
-  private clearPlaceholderNodes(
-    editor: LexicalEditor,
-    options?: { restoreSelection?: boolean },
-  ): void {
-    const shouldRestoreSelection = options?.restoreSelection ?? true;
-    const restoreSelection = this.placeholderSelectionSnapshot;
-
-    // Reset state immediately so listeners see no active suggestion
-    this.currentSuggestion = null;
-    this.currentSuggestionId = null;
-    this.suggestionShownAt = 0;
-    this.placeholderAnchorPosition = null;
-    this.placeholderSelectionSnapshot = null;
-    // Cancel any pending AI timer
-    this.clearTimer();
-
-    // Check if there are actually placeholder nodes before queuing an update.
-    // An empty editor.update() still fires listeners and can cause loops.
-    let hasPlaceholderNodes = false;
-    editor.getEditorState().read(() => {
-      hasPlaceholderNodes =
-        $nodesOfType(PlaceholderNode).length > 0 || $nodesOfType(PlaceholderBlockNode).length > 0;
-    });
-
-    if (!hasPlaceholderNodes && !(shouldRestoreSelection && restoreSelection)) {
-      // Nothing to do — skip the update entirely to avoid triggering listeners
-      this.skipNextTextContentListener = false;
-      return;
-    }
-
-    // Skip the textContentListener that fires when we remove placeholder nodes
-    this.skipNextTextContentListener = true;
-    editor.update(
-      () => {
-        for (const node of $nodesOfType(PlaceholderNode)) {
-          node.remove();
-        }
-        for (const node of $nodesOfType(PlaceholderBlockNode)) {
-          node.remove();
-        }
-
-        if (shouldRestoreSelection && restoreSelection) {
-          $setSelection(restoreSelection);
-        }
+      {
+        tag: [PREVIEW_TAG, HISTORY_PUSH_TAG],
+        onUpdate: () => {
+          try {
+            this.config?.onSuggestionAccepted?.({
+              acceptedText: preview.markdown,
+              suggestionId: preview.id,
+              visibleMs: Date.now() - preview.shownAt,
+            });
+          } catch (error) {
+            this.logger.warn('Auto-complete acceptance callback failed:', error);
+          }
+        },
       },
-      { tag: HISTORIC_TAG },
     );
-  }
-
-  private applySuggestion(editor: LexicalEditor): void {
-    if (!this.currentSuggestion) {
-      return;
-    }
-
-    const markdown = this.currentSuggestion;
-    const suggestionId = this.currentSuggestionId;
-    const suggestionShownAt = this.suggestionShownAt;
-
-    editor.update(() => {
-      const selection = $getSelection();
-      if (!$isRangeSelection(selection) || !selection.isCollapsed() || !this.markdownService) {
-        return;
-      }
-
-      if (suggestionId) {
-        this.config?.onSuggestionAccepted?.({
-          acceptedText: markdown,
-          suggestionId,
-          visibleMs: Date.now() - suggestionShownAt,
-        });
-      }
-
-      for (const node of $nodesOfType(PlaceholderNode)) {
-        node.remove();
-      }
-      for (const node of $nodesOfType(PlaceholderBlockNode)) {
-        node.remove();
-      }
-
-      const nodes = this.markdownService.parseMarkdownToLexical(markdown);
-      this.markdownService.insertIRootNode(editor, nodes, selection);
-
-      this.clearPlaceholderNodes(editor, { restoreSelection: false });
-    });
-  }
-
-  private isSamePosition(
-    pos1: { key: string; offset: number; type: string },
-    pos2: { key: string; offset: number; type: string },
-  ): boolean {
-    return pos1.key === pos2.key && pos1.offset === pos2.offset && pos1.type === pos2.type;
   }
 
   destroy(): void {
-    this.clearTimer();
+    this.phase = 'destroyed';
+    this.cancelRequest();
+    this.cancelSettlement();
     super.destroy();
+    this.removePreview();
   }
 };

--- a/src/react/Editor/demos/index.tsx
+++ b/src/react/Editor/demos/index.tsx
@@ -109,6 +109,10 @@ const styles = createStaticStyles(({ css, cssVar }) => ({
   `,
   editor: css`
     padding: 16px;
+
+    > [data-lexical-editor]:focus-visible {
+      outline: none;
+    }
   `,
   linkCard: css`
     display: inline-flex;
@@ -560,10 +564,7 @@ const EditorDemo: FC<EditorDemoProps> = ({
       xml={xml}
       {...props}
     >
-      <div className={styles.controls}>
-        <Toolbar editor={editor} />
-        {renderControls?.(editor)}
-      </div>
+      {renderControls && <div className={styles.controls}>{renderControls(editor)}</div>}
       <Editor
         className={styles.editor}
         content={editorContent}


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

自动补全预览原先通过正式 Markdown 插入流程修改正文，并由多个监听器清理节点和恢复选区，容易干扰中文输入法的组词与上屏过程。本次重写补全生命周期，针对组词卡顿、拼音残留及预览清理问题收紧文档更新边界。

- 使用单一更新监听器和明确的状态流程管理请求、预览、取消与接受；请求返回时核对光标和正文上下文，丢弃过期结果。
- 将多段预览放在一个不可编辑的行内容器中，保留灰字、换行和撑开正文的 UI，取消时不拆分原正文段落。
- 预览插入前先提交待处理的用户更新，再使用独立的预览事务，避免 `PREVIEW_TAG` 随合批更新跳过用户输入的失效判断。
- 原生组词开始时用 `display: none` 隐藏预览；等待上屏事件及 Lexical 更新完成后清理，不恢复旧选区。
- 保留现有 API，覆盖 Tab 接受、撤销、失焦取消与卸载重挂载清理。

- 简化 Playground 示例：移除顶部固定工具栏，并局部覆盖编辑区域的全局焦点边框；已在浏览器中验证聚焦效果。

#### 📝 补充信息 | Additional Information

验证：

- 18 个相关测试通过，包含 DOM 预编辑 `a` → `啊`、两种请求返回/用户输入合批顺序、连续取消后的文本归一化、Safari 延迟 `insertFromComposition`、预览生命周期及 Markdown 插入回归。
- 类型检查、ESLint、构建、循环依赖检查通过。
- Chrome + macOS + 搜狗输入法初步人工测试反馈正常；Windows 微软拼音及 macOS Safari 原生人工测试待验证。

自动化 DOM 事件测试不等同于所有原生输入法实现的兼容性验收。



实现边界：多段预览使用瞬态行内包装器承载块 DOM，不将其 `innerHTML` 作为可移植 HTML；接受时重新解析 Markdown。旧 `PlaceholderBlock` 节点和主题选项为反序列化兼容保留。
