### PR TITLE
🐛 fix(common): normalize caret parked at root start before a block decorator

### DIFF
--- a/src/plugins/common/node/__tests__/cursor-root-start.test.ts
+++ b/src/plugins/common/node/__tests__/cursor-root-start.test.ts
@@ -1,0 +1,210 @@
+import type { LexicalEditor, LexicalNode, NodeKey } from 'lexical';
+import {
+  $createParagraphNode,
+  $createRangeSelection,
+  $createTextNode,
+  $getRoot,
+  $getSelection,
+  $isDecoratorNode,
+  $isParagraphNode,
+  $isRangeSelection,
+  $setSelection,
+  DecoratorNode,
+  KEY_ARROW_LEFT_COMMAND,
+} from 'lexical';
+import { describe, expect, it } from 'vitest';
+
+import type { IEditorKernel } from '@/types/kernel';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+
+import {
+  $isCaretAtRootStartBeforeBlockDecorator,
+  $insertParagraphBeforeRootStartBlock,
+} from '../cursor';
+
+/** Minimal non-inline decorator standing in for BlockImageNode / HorizontalRuleNode. */
+class FakeBlockNode extends DecoratorNode<null> {
+  static getType(): string {
+    return 'fake-block';
+  }
+
+  static clone(node: FakeBlockNode): FakeBlockNode {
+    return new FakeBlockNode(node.__key);
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-inferrable-types
+  constructor(key: NodeKey | undefined = undefined) {
+    super(key);
+  }
+
+  createDOM(): HTMLElement {
+    return document.createElement('div');
+  }
+
+  updateDOM(): false {
+    return false;
+  }
+
+  isInline(): false {
+    return false;
+  }
+
+  decorate(): null {
+    return null;
+  }
+}
+
+function update(editor: LexicalEditor, callback: () => void): void {
+  editor.update(callback, { discrete: true });
+}
+
+function setup() {
+  const kernel = Editor.createEditor() as IEditorKernel;
+  kernel.registerNodes([FakeBlockNode]);
+  kernel.registerPlugins([CommonPlugin]);
+  kernel.setRootElement(document.createElement('div'));
+
+  const editor = kernel.getLexicalEditor();
+  if (!editor) throw new Error('Editor not found');
+  return editor;
+}
+
+describe('$isCaretAtRootStartBeforeBlockDecorator', () => {
+  it('detects a collapsed caret parked at root offset 0 before a block decorator', () => {
+    const editor = setup();
+
+    update(editor, () => {
+      const root = $getRoot();
+      root.clear();
+      root.append(new FakeBlockNode());
+      const selection = $createRangeSelection();
+      selection.anchor.set('root', 0, 'element');
+      selection.focus.set('root', 0, 'element');
+      $setSelection(selection);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($isCaretAtRootStartBeforeBlockDecorator()).toBe(true);
+    });
+  });
+
+  it('returns false when the caret is inside a normal paragraph', () => {
+    const editor = setup();
+
+    update(editor, () => {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      const text = $createTextNode('start');
+      paragraph.append(text);
+      root.append(paragraph);
+      root.append(new FakeBlockNode());
+      const selection = $createRangeSelection();
+      selection.anchor.set(text.getKey(), 0, 'text');
+      selection.focus.set(text.getKey(), 0, 'text');
+      $setSelection(selection);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($isCaretAtRootStartBeforeBlockDecorator()).toBe(false);
+    });
+  });
+
+  it('returns false for non-collapsed selections', () => {
+    const editor = setup();
+
+    update(editor, () => {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      const text = $createTextNode('start');
+      paragraph.append(text);
+      root.append(paragraph);
+      const selection = $createRangeSelection();
+      selection.anchor.set(text.getKey(), 0, 'text');
+      selection.focus.set(text.getKey(), text.getTextContentSize(), 'text');
+      $setSelection(selection);
+    });
+
+    editor.getEditorState().read(() => {
+      expect($isCaretAtRootStartBeforeBlockDecorator()).toBe(false);
+    });
+  });
+});
+
+describe('$insertParagraphBeforeRootStartBlock', () => {
+  it('inserts a leading paragraph and anchors the selection inside it', () => {
+    const editor = setup();
+
+    update(editor, () => {
+      const root = $getRoot();
+      root.clear();
+      root.append(new FakeBlockNode());
+      const selection = $createRangeSelection();
+      selection.anchor.set('root', 0, 'element');
+      selection.focus.set('root', 0, 'element');
+      $setSelection(selection);
+    });
+
+    update(editor, () => {
+      const firstChild = $getRoot().getFirstChild();
+      if (!firstChild || firstChild.isInline() || !$isDecoratorNode(firstChild)) return;
+      $insertParagraphBeforeRootStartBlock();
+    });
+
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      expect(root.getChildrenSize()).toBe(2);
+      expect($isParagraphNode(root.getFirstChild())).toBe(true);
+      expect($isDecoratorNode(root.getLastChild())).toBe(true);
+
+      const selection = $getSelection();
+      expect($isRangeSelection(selection)).toBe(true);
+      if (!$isRangeSelection(selection)) return;
+      expect(selection.anchor.getNode().getType()).toBe('paragraph');
+    });
+  });
+
+  it('keeps the block after an existing paragraph when ArrowLeft crosses the boundary', () => {
+    const editor = setup();
+
+    update(editor, () => {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('hello'));
+      root.append(paragraph);
+      root.append(new FakeBlockNode());
+
+      const selection = $createRangeSelection();
+      selection.anchor.set(paragraph.getKey(), 0, 'element');
+      selection.focus.set(paragraph.getKey(), 0, 'element');
+      $setSelection(selection);
+    });
+
+    editor.dispatchCommand(
+      KEY_ARROW_LEFT_COMMAND,
+      new KeyboardEvent('keydown', { key: 'ArrowLeft' }),
+    );
+
+    // The core guarantee: wherever the caret ends up (root offset 0 or inside
+    // the first paragraph), a leading paragraph keeps the caret in a real
+    // text anchor. Exercise the normalization explicitly.
+    update(editor, () => {
+      const firstChild = $getRoot().getFirstChild();
+      if (!firstChild || firstChild.isInline() || !$isDecoratorNode(firstChild)) return;
+      $insertParagraphBeforeRootStartBlock();
+    });
+
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      const types = root.getChildren().map((node) => node.getType());
+      expect(types[0]).toBe('paragraph');
+      expect(types.filter((type) => type === 'fake-block').length).toBe(1);
+      const selection = $getSelection();
+      expect($isRangeSelection(selection)).toBe(true);
+    });
+  });
+});

--- a/src/plugins/common/node/cursor.ts
+++ b/src/plugins/common/node/cursor.ts
@@ -1,8 +1,10 @@
 import { mergeRegister } from '@lexical/utils';
 import type { LexicalEditor, LexicalNode, SerializedLexicalNode } from 'lexical';
 import {
+  $createParagraphNode,
   $createTextNode,
   $getNodeByKey,
+  $getRoot,
   $getSelection,
   $isDecoratorNode,
   $isRangeSelection,
@@ -61,8 +63,76 @@ export function $isCursorNode(node: LexicalNode | null | undefined): node is Cur
   return node instanceof CursorNode;
 }
 
+/**
+ * A cursor parked at the very start of the root (offset 0) has no text to
+ * anchor to when the first child is a non-inline decorator (block image, HR,
+ * ...). The browser then renders a floating caret across the block (the
+ * "horizontal cursor" artifact) and typing mutates the wrong position.
+ * Normalizing to a leading empty paragraph (a la Linear) gives the caret a
+ * real home.
+ */
+export function $isCaretAtRootStartBeforeBlockDecorator(): boolean {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
+
+  const { key, offset, type } = selection.anchor;
+  if (key !== 'root') return false;
+  if (type === 'text') return false;
+  if (offset !== 0) return false;
+
+  const firstChild = $getRoot().getFirstChild();
+  return Boolean(firstChild && firstChild.isInline() === false && $isDecoratorNode(firstChild));
+}
+
+export function $insertParagraphBeforeRootStartBlock(): void {
+  const firstChild = $getRoot().getFirstChild();
+  if (!firstChild) return;
+
+  const paragraph = $createParagraphNode();
+  firstChild.insertBefore(paragraph);
+  paragraph.select(0, 0);
+}
+
 export function registerCursorNode(editor: LexicalEditor) {
+  let isNormalizingRootStartCaret = false;
+
   return mergeRegister(
+    // Keep a caret parked at root-start (offset 0) in front of a leading
+    // non-inline decorator from lingering there: normalize it into a fresh
+    // empty paragraph. Runs passively so every selection path (ArrowLeft,
+    // ArrowUp from the next block, click on the top gap, NodeSelection +
+    // ArrowLeft, ...) lands in a real text anchor.
+    editor.registerUpdateListener(() => {
+      if (isNormalizingRootStartCaret) return;
+      const needsNormalize = editor
+        .getEditorState()
+        .read(() => (editor.isComposing() ? false : $isCaretAtRootStartBeforeBlockDecorator()));
+      if (!needsNormalize) return;
+
+      isNormalizingRootStartCaret = true;
+      queueMicrotask(() => {
+        isNormalizingRootStartCaret = false;
+        // Re-verify against the committed editor state: the caret position
+        // that triggered this path may already have been reconciled away.
+        const stillNeeded = editor
+          .getEditorState()
+          .read(() => $isCaretAtRootStartBeforeBlockDecorator());
+        if (!stillNeeded) return;
+
+        editor.update(
+          () => {
+            // The selection itself does not survive DOM reconciliation at
+            // this unrepresentable position, so only structural state is
+            // re-checked here; the paragraph brings its own fresh selection.
+            const firstChild = $getRoot().getFirstChild();
+            if (!firstChild || firstChild.isInline() || !$isDecoratorNode(firstChild)) return;
+
+            $insertParagraphBeforeRootStartBlock();
+          },
+          { tag: HISTORY_MERGE_TAG, discrete: true },
+        );
+      });
+    }),
     editor.registerUpdateListener(({ mutatedNodes }) => {
       editor.getEditorState().read(() => {
         if (!mutatedNodes) return;


### PR DESCRIPTION
## 🔗 Related issue / 背景

来自 @lobehub 主仓库 dev 频道的边缘 case 反馈：

> 这应该是一个边缘 case，像 linear 这种第一行是图片，向左唤出光标，会自动顶一行空行。这个应该没处理顶一个空行，直接就加载在上面了
>
> 像是编辑器层面的 bug，我在正文中粘贴图片的时候也会先横向光标，然后再转成纵向

## 🐛 问题分析

当文档第一个子节点是 **非 inline 的 DecoratorNode**（BlockImageNode、HorizontalRuleNode 等）时：

1. 向左 / 向上移动光标越过块边界，selection 会落到 **root offset 0** —— 这个位置没有任何文本锚点
2. 浏览器只能把光标画在块节点上，产生 **横向光标 / 光标闪烁** 的视觉 artifact
3. 此时光标不可用、输入行为异常，且不像 Linear 那样自动顶一行空行

现有的 `CursorNode` 机制只覆盖了 **inline 装饰节点**（行内图片）的光标锚点，块级装饰节点前没有对应处理。

## ✨ 修复方案

在 `registerCursorNode` 中新增一个被动规范化 listener（Linear 同款行为）：

- `()` — 检测「collapsed selection 停在 root offset 0 且第一个子节点是非 inline 装饰节点」
- `()` — 在块前插入空段落并把 selection 锚定进去
- listener 在每次 update 后被动触发（带重入 guard + `queueMicrotask` 延迟避免 update 循环），因此**所有**光标落点路径都会被规范化：
  - 块后段落按 ArrowLeft / ArrowUp
  - 点击顶部空白区域
  - NodeSelection 上按 ArrowLeft
  - 直接 load 进这个状态的文档

关键细节：caret 停在 root offset 0 的 selection 在 DOM reconcile 时**本身无法保留**，所以 update 事务内只做结构校验、不重新检查 selection，插入的段落自带全新合法 selection。

## ✅ 验证

- 新增 5 个单测（`cursor-root-start.test.ts`）：detector 正/反例、插入后结构与 caret 落点、ArrowLeft 跨块边界
- `vitest run src/plugins/common`：8 个文件 50 个测试全部通过，无回归
- `tsc --noEmit` 通过；循环依赖检查通过

## 📌 备注

粘贴图片时「先横向光标再转纵向」是同一根因的另一种表现：块级图片插入后 selection 短暂落在不可表达的 DOM 位置。本次的被动规范化会在下一次 update 时把这种情况收敛掉。