### PR TITLE
⚡️ perf(send-button): use CSS transform for generating spinner

### DIFF
--- a/src/react/SendButton/components/StopIcon.tsx
+++ b/src/react/SendButton/components/StopIcon.tsx
@@ -3,8 +3,29 @@ import { type CSSProperties, type FC } from 'react';
 
 const styles = createStaticStyles(({ css }) => ({
   icon: css`
+    position: relative;
+    display: inline-block;
     flex: none;
     line-height: 1;
+  `,
+  layer: css`
+    position: absolute;
+    inset: 0;
+
+    display: block;
+
+    width: 100%;
+    height: 100%;
+  `,
+  spinner: css`
+    transform-origin: 50% 50%;
+    animation: send-button-stop-spin 1s linear infinite;
+
+    @keyframes send-button-stop-spin {
+      to {
+        transform: rotate(360deg);
+      }
+    }
   `,
 }));
 
@@ -15,42 +36,34 @@ interface StopIconProps {
 
 const StopIcon: FC<StopIconProps> = ({ size = '1.5em', style }) => {
   return (
-    <svg
-      className={cx('anticon', styles.icon)}
-      color="currentColor"
-      height={size}
-      style={style}
-      viewBox="0 0 1024 1024"
-      width={size}
-      xmlns="http://www.w3.org/2000/svg"
-    >
-      <g fill="none">
-        <circle
-          cx="512"
-          cy="512"
-          fill="none"
-          r="426"
-          stroke={cssVar.colorBorder}
-          strokeWidth="72"
-        />
+    <span className={cx('anticon', styles.icon)} style={{ height: size, width: size, ...style }}>
+      <svg
+        className={styles.layer}
+        fill="none"
+        height={size}
+        viewBox="0 0 1024 1024"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <circle cx="512" cy="512" r="426" stroke={cssVar.colorBorder} strokeWidth="72" />
         <rect fill="currentColor" height="252" rx="24" ry="24" width="252" x="386" y="386" />
+      </svg>
+      <svg
+        className={cx(styles.layer, styles.spinner)}
+        fill="none"
+        height={size}
+        viewBox="0 0 1024 1024"
+        width={size}
+        xmlns="http://www.w3.org/2000/svg"
+      >
         <path
           d="M938.667 512C938.667 276.359 747.64 85.333 512 85.333"
           stroke="currentColor"
           strokeLinecap="round"
           strokeWidth="73"
-        >
-          <animateTransform
-            attributeName="transform"
-            dur="1s"
-            from="0 512 512"
-            repeatCount="indefinite"
-            to="360 512 512"
-            type="rotate"
-          />
-        </path>
-      </g>
-    </svg>
+        />
+      </svg>
+    </span>
   );
 };
 


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [x] 🔨 chore
- [ ] 📝 docs

This is a performance change (compositor CSS animation). Closest template box is chore; the commit uses `⚡️ perf`.

#### 🔀 变更说明 | Description of Change

`SendButton` generating state used SVG SMIL `<animateTransform>` on the stop-icon arc. SMIL updates the SVG transform attribute on the main thread and is not compositor-accelerated.

This splits the static ring/stop square and the spinning arc into two stacked SVGs, then rotates the arc SVG with a CSS `transform` animation (`send-button-stop-spin`, 1s linear infinite). Chromium can run that CSS transform on the compositor, so the spinner is no longer a per-frame SVG paint.

Visual result is unchanged: square stays still, arc orbits around the viewBox center.

#### 📝 补充信息 | Additional Information

Verified on the SendButton docs demo (`generating` / `generating` + menu / round variants): no `<animateTransform>` in the DOM, `getAnimations()` reports a running CSSAnimation on `transform`, and two captured frames show the arc moving while the stop square does not.

ChatInput in lobe-chat consumes this component via `@lobehub/editor`.