### PR TITLE
✨ feat: export the React provider on its own subpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
       "types": "./es/react.d.ts",
       "import": "./es/react.js"
     },
+    "./react/EditorProvider": {
+      "types": "./es/react/EditorProvider/index.d.ts",
+      "import": "./es/react/EditorProvider/index.js"
+    },
     "./renderer": {
       "types": "./es/renderer.d.ts",
       "import": "./es/renderer.js"


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [x] ✨ feat
- [ ] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`@lobehub/editor/react` re-exports the whole editor runtime (lexical, yjs, fuse), and bundlers do not shake that entry down to `EditorProvider`. An app that only mounts the provider at its root — to supply the editor locale, say — pays for the entire runtime on its first screen. In LobeHub that edge alone put ~330 KB gzip of lexical/yjs/fuse into the boot chunk.

This adds one export-map entry:

```json
"./react/EditorProvider": {
  "types": "./es/react/EditorProvider/index.d.ts",
  "import": "./es/react/EditorProvider/index.js"
}
```

The browser build is already `unbundle: true`, so `es/react/EditorProvider/index.js` and its `.d.ts` are published today — this only makes them reachable. No build or source change.

#### 📝 补充信息 | Additional Information

Verified against the published 4.26.1 package with the entry patched in:

- `import.meta.resolve('@lobehub/editor/react/EditorProvider')` resolves to `es/react/EditorProvider/index.js`
- consuming app type-checks clean with no ambient shim
- consuming app production build unchanged in size, with the editor runtime off the first screen

LobeHub is working around this today with a bundler resolver plugin (lobehub/lobehub#19325); once this ships that plugin's build path can be deleted.

https://claude.ai/code/session_01LNsSw6SDv3UEGNfBEwPa8S