### PR TITLE
🐛 fix: preserve slash shortcuts and mention caret

### DIFF
--- a/src/plugins/mention/command/__tests__/command.test.ts
+++ b/src/plugins/mention/command/__tests__/command.test.ts
@@ -1,9 +1,16 @@
 // @vitest-environment node
-import { $createParagraphNode, $getRoot, $getSelection, $isRangeSelection } from 'lexical';
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isRangeSelection,
+  $nodesOfType,
+} from 'lexical';
 import { describe, expect, it } from 'vitest';
 
 import Editor from '@/editor-kernel';
 import { $isCursorNode, CommonPlugin } from '@/plugins/common';
+import { MentionNode } from '@/plugins/mention/node/MentionNode';
 import { MentionPlugin } from '@/plugins/mention/plugin';
 
 import { INSERT_MENTION_COMMAND } from '..';
@@ -43,6 +50,41 @@ describe('mention commands', () => {
 
       expect($isRangeSelection(selection)).toBe(true);
       expect($isRangeSelection(selection) && $isCursorNode(selection.anchor.getNode())).toBe(true);
+    });
+  });
+
+  it('inserts a mention without requiring CommonPlugin', async () => {
+    const editor = Editor.createEditor().registerPlugins([MentionPlugin]);
+    const errors: Error[] = [];
+    editor.on('error', (error) => errors.push(error));
+    editor.initNodeEditor();
+
+    const lexicalEditor = editor.getLexicalEditor();
+    if (!lexicalEditor) {
+      throw new Error('Lexical editor not initialized');
+    }
+
+    lexicalEditor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().clear().append(paragraph);
+        paragraph.selectEnd();
+      },
+      { discrete: true },
+    );
+
+    expect(() =>
+      editor.dispatchCommand(INSERT_MENTION_COMMAND, {
+        label: 'Ada',
+        metadata: { id: '42' },
+      }),
+    ).not.toThrow();
+    await flushEditorUpdates();
+
+    expect(errors).toEqual([]);
+    lexicalEditor.getEditorState().read(() => {
+      expect($nodesOfType(MentionNode)).toHaveLength(1);
+      expect($getRoot().getTextContent()).toBe('Ada');
     });
   });
 });

--- a/src/plugins/mention/command/__tests__/command.test.ts
+++ b/src/plugins/mention/command/__tests__/command.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { $createParagraphNode, $getRoot, $getSelection, $isRangeSelection } from 'lexical';
+import { describe, expect, it } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { $isCursorNode, CommonPlugin } from '@/plugins/common';
+import { MentionPlugin } from '@/plugins/mention/plugin';
+
+import { INSERT_MENTION_COMMAND } from '..';
+
+const flushEditorUpdates = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('mention commands', () => {
+  it('places the caret in the cursor node after an inserted mention', async () => {
+    const editor = Editor.createEditor().registerPlugins([CommonPlugin, MentionPlugin]);
+    editor.initNodeEditor();
+
+    const lexicalEditor = editor.getLexicalEditor();
+    if (!lexicalEditor) {
+      throw new Error('Lexical editor not initialized');
+    }
+
+    lexicalEditor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        $getRoot().clear().append(paragraph);
+        paragraph.selectEnd();
+      },
+      { discrete: true },
+    );
+
+    editor.dispatchCommand(INSERT_MENTION_COMMAND, {
+      label: 'Ada',
+      metadata: { id: '42' },
+    });
+    await flushEditorUpdates();
+
+    lexicalEditor.getEditorState().read(() => {
+      const selection = $getSelection();
+
+      expect($isRangeSelection(selection)).toBe(true);
+      expect($isRangeSelection(selection) && $isCursorNode(selection.anchor.getNode())).toBe(true);
+    });
+  });
+});

--- a/src/plugins/mention/command/index.ts
+++ b/src/plugins/mention/command/index.ts
@@ -8,6 +8,8 @@ import {
   createCommand,
 } from 'lexical';
 
+import { $createCursorNode } from '@/plugins/common/node/cursor';
+
 import { $createMentionNode } from '../node/MentionNode';
 
 export const INSERT_MENTION_COMMAND = createCommand<{
@@ -25,8 +27,11 @@ export function registerMentionCommand(editor: LexicalEditor) {
         $insertNodes([mentionNode]);
         // Ensure mention is inside a paragraph when inserted at root
         if ($isRootOrShadowRoot(mentionNode.getParentOrThrow())) {
-          $wrapNodeInElement(mentionNode, $createParagraphNode).selectEnd();
+          $wrapNodeInElement(mentionNode, $createParagraphNode);
         }
+        const cursorNode = $createCursorNode();
+        mentionNode.insertAfter(cursorNode);
+        cursorNode.selectEnd();
       });
       return true;
     },

--- a/src/plugins/mention/command/index.ts
+++ b/src/plugins/mention/command/index.ts
@@ -8,7 +8,7 @@ import {
   createCommand,
 } from 'lexical';
 
-import { $createCursorNode } from '@/plugins/common/node/cursor';
+import { $createCursorNode, CursorNode } from '@/plugins/common/node/cursor';
 
 import { $createMentionNode } from '../node/MentionNode';
 
@@ -22,16 +22,22 @@ export function registerMentionCommand(editor: LexicalEditor) {
     INSERT_MENTION_COMMAND,
     (payload) => {
       const { metadata, label } = payload;
+      const hasCursorNode = editor.hasNodes([CursorNode]);
       editor.update(() => {
         const mentionNode = $createMentionNode(label, metadata);
         $insertNodes([mentionNode]);
         // Ensure mention is inside a paragraph when inserted at root
         if ($isRootOrShadowRoot(mentionNode.getParentOrThrow())) {
-          $wrapNodeInElement(mentionNode, $createParagraphNode);
+          const paragraph = $wrapNodeInElement(mentionNode, $createParagraphNode);
+          if (!hasCursorNode) {
+            paragraph.selectEnd();
+          }
         }
-        const cursorNode = $createCursorNode();
-        mentionNode.insertAfter(cursorNode);
-        cursorNode.selectEnd();
+        if (hasCursorNode) {
+          const cursorNode = $createCursorNode();
+          mentionNode.insertAfter(cursorNode);
+          cursorNode.selectEnd();
+        }
       });
       return true;
     },

--- a/src/plugins/slash/plugin/index.test.ts
+++ b/src/plugins/slash/plugin/index.test.ts
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { $createParagraphNode, $createTextNode, $getRoot } from 'lexical';
+import { describe, expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+
+import { SlashPlugin } from '.';
+
+vi.mock('../utils/utils', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../utils/utils')>();
+
+  return {
+    ...actual,
+    tryToPositionRange: () => true,
+  };
+});
+
+const flushEditorUpdates = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+};
+
+describe('SlashPlugin', () => {
+  it('keeps a max-length keyboard shortcut query open', async () => {
+    const item = { key: 'insert-codeBlock', label: 'InsertCodeBlock' };
+    const triggerOpen = vi.fn();
+    const editor = Editor.createEditor().registerPlugins([
+      CommonPlugin,
+      [
+        SlashPlugin,
+        {
+          slashOptions: [{ items: [item], maxLength: 16, trigger: '/' }],
+          triggerClose: vi.fn(),
+          triggerOpen,
+        },
+      ],
+    ]);
+    editor.initNodeEditor();
+
+    const lexicalEditor = editor.getLexicalEditor();
+    if (!lexicalEditor) {
+      throw new Error('Lexical editor not initialized');
+    }
+
+    lexicalEditor.update(
+      () => {
+        const paragraph = $createParagraphNode();
+        const text = $createTextNode('/insert-codeBlock');
+        paragraph.append(text);
+        $getRoot().clear().append(paragraph);
+        text.selectEnd();
+      },
+      { discrete: true },
+    );
+    await flushEditorUpdates();
+
+    expect(triggerOpen).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        items: [item],
+        match: expect.objectContaining({ matchingString: 'insert-codeBlock' }),
+        trigger: '/',
+      }),
+    );
+  });
+});

--- a/src/plugins/slash/plugin/index.ts
+++ b/src/plugins/slash/plugin/index.ts
@@ -241,10 +241,8 @@ export const SlashPlugin: IEditorPluginConstructor<SlashPluginOptions> = class
             return;
           }
           const slashOptions = this.service?.getSlashOptions(triggerText);
-          const maxLength = slashOptions?.maxLength || 75;
 
-          // Exceeds maximum length
-          if (text.length - lastIndex > maxLength || !slashOptions) {
+          if (!slashOptions) {
             this.triggerClose();
             return;
           }

--- a/src/plugins/slash/service/i-slash-service.test.ts
+++ b/src/plugins/slash/service/i-slash-service.test.ts
@@ -40,6 +40,24 @@ describe('SlashService', () => {
     expect(match?.matchingString).toBe('code-review');
   });
 
+  it('finds a keyboard shortcut whose slash query contains a hyphen', () => {
+    const service = createService();
+    service.registerSlash({
+      items: [{ key: 'insert-codeInline', label: 'Insert code inline' }],
+      trigger: '/',
+    });
+
+    const match = service.getSlashTriggerFn('/')?.('/insert-codeInline');
+    const matches = match
+      ? service
+          .getSlashFuse('/')!
+          .search(match.matchingString)
+          .map(({ item }) => item.key)
+      : [];
+
+    expect(matches).toEqual(['insert-codeInline']);
+  });
+
   it('recovers an existing trigger after backspace removes an invalid boundary', () => {
     const service = createService();
     registerDefaultTriggers(service);


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

- Preserve hyphens while matching slash-menu keyboard shortcut queries.
- Honor the configured slash query `maxLength` without counting the trigger twice.
- Insert and select a trailing cursor node after a mention so the caret remains visible.
- Add service, plugin, and mention command regression coverage.

#### 📝 补充信息 | Additional Information

- Browser verified `/insert-codeBlock` filtering and post-mention typing.
- `pnpm vitest run` — 509 passed, 1 skipped
- `pnpm type-check`
- `pnpm lint:circular`