### PR TITLE
🐛 fix: make Lexical postinstall patching safe for concurrent installs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Install deps
         run: pnpm install
 
+      - name: Test concurrent postinstall patching
+        run: node --test scripts/postinstall-lexical-patch.test.cjs
+
       - name: CI
         run: pnpm run ci
 

--- a/scripts/postinstall-lexical-patch.cjs
+++ b/scripts/postinstall-lexical-patch.cjs
@@ -245,10 +245,19 @@ function patchPackage({ displayName, fileHashes, packageName, patchFile, ...conf
       );
     }
 
-    fs.writeFileSync(
-      targetPath,
-      restoreLineEndings(patchedContent, detectLineEnding(currentContent)),
-    );
+    // Peer-dependent editor instances can patch the same dependency concurrently.
+    // Publish a complete file so other patchers never read a partial write.
+    const temporaryPath = `${targetPath}.${crypto.randomUUID()}.tmp`;
+    try {
+      fs.writeFileSync(
+        temporaryPath,
+        restoreLineEndings(patchedContent, detectLineEnding(currentContent)),
+        { flag: 'wx', mode: fs.statSync(targetPath).mode },
+      );
+      fs.renameSync(temporaryPath, targetPath);
+    } finally {
+      fs.rmSync(temporaryPath, { force: true });
+    }
     patchedFiles.push(filename);
   }
 

--- a/scripts/postinstall-lexical-patch.test.cjs
+++ b/scripts/postinstall-lexical-patch.test.cjs
@@ -1,0 +1,76 @@
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { test } = require('node:test');
+
+const script = path.join(__dirname, 'postinstall-lexical-patch.cjs');
+
+test('concurrent installers never observe partially written Lexical files', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'editor-patch-race-'));
+  try {
+    const env = { ...process.env };
+    for (const [name, variable, patch] of [
+      ['lexical', 'LOBE_EDITOR_LEXICAL_ROOT', 'lexical@0.42.0.patch'],
+      ['@lexical/yjs', 'LOBE_EDITOR_LEXICAL_YJS_ROOT', '@lexical__yjs@0.42.0.patch'],
+    ]) {
+      const source = process.env[variable] || path.dirname(require.resolve(name));
+      const target = path.join(root, name);
+      fs.cpSync(source, target, { dereference: true, recursive: true });
+      env[variable] = target;
+      // Normal installs are already patched; also accept pristine package fixtures.
+      const patchFile = path.join(__dirname, '..', 'patches', patch);
+      const reverse = spawnSync('git', ['apply', '--reverse', '--check', patchFile], {
+        cwd: target,
+      });
+      if (reverse.status === 0) {
+        const result = spawnSync('git', ['apply', '--reverse', patchFile], { cwd: target });
+        assert.equal(result.status, 0, result.stderr.toString());
+      }
+    }
+    const hook = path.join(root, 'interrupt-write.cjs');
+    const resultFile = path.join(root, 'reader.json');
+    fs.writeFileSync(
+      hook,
+      `const fs = require('node:fs');
+const { spawnSync } = require('node:child_process');
+const originalWrite = fs.writeFileSync;
+let interrupted = false;
+fs.writeFileSync = function (file, content, options) {
+  if (!interrupted && String(file).includes('Lexical.dev.js')) {
+    interrupted = true;
+    const fd = fs.openSync(file, 'w');
+    fs.writeSync(fd, content.slice(0, Math.floor(content.length / 2)));
+    fs.closeSync(fd);
+    const reader = spawnSync(process.execPath, [${JSON.stringify(script)}], {
+      env: process.env, encoding: 'utf8', timeout: 10000,
+    });
+    originalWrite(${JSON.stringify(resultFile)}, JSON.stringify({
+      status: reader.status, stderr: reader.stderr, error: reader.error?.message,
+    }));
+    // The intercepted write already created the file; finish that same write.
+    return originalWrite(file, content, { ...options, flag: 'w' });
+  }
+  return originalWrite(file, content, options);
+};
+`,
+    );
+    const writer = spawnSync(process.execPath, ['--require', hook, script], {
+      env,
+      encoding: 'utf8',
+      timeout: 20000,
+    });
+    assert.equal(writer.status, 0, writer.stderr);
+    const reader = JSON.parse(fs.readFileSync(resultFile, 'utf8'));
+    assert.equal(reader.status, 0, reader.stderr || reader.error);
+    const repeat = spawnSync(process.execPath, [script], { env, encoding: 'utf8' });
+    assert.equal(repeat.status, 0, repeat.stderr);
+    assert.equal(repeat.stdout, '', 'Both dependencies should already be completely patched');
+    for (const variable of ['LOBE_EDITOR_LEXICAL_ROOT', 'LOBE_EDITOR_LEXICAL_YJS_ROOT']) {
+      assert.ok(!fs.readdirSync(env[variable]).some((name) => name.endsWith('.tmp')));
+    }
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

Multiple pnpm editor instances can run postinstall against the same Lexical dependency concurrently. A direct write truncates the destination, so another installer can read incomplete content and fail with `Patch context mismatch`, even when both instances carry identical patches.

Write each verified patch to a unique sibling temporary file and rename it over the destination only after the write completes. Readers see complete content, the existing patched-hash check remains idempotent, file modes are preserved, and temporary files are cleaned on failure. This applies to both Lexical and Lexical Yjs.

Add a deterministic regression test that starts a second installer while the first file write is half complete, and run it in Test CI.

#### 📝 补充信息 | Additional Information

- Reproduced in https://github.com/lobehub/lobehub/actions/runs/34368919446/job/102525568042?pr=19351. Published editor 4.26.2 and 4.27.0 have identical patch scripts and patches for Lexical 0.42.0.
- The regression test fails against the old script and passes with this change, using both pristine package fixtures and already-patched installed dependencies.
- 30 stress rounds with three concurrent installers each passed (90 processes).
- `node --test scripts/postinstall-lexical-patch.test.cjs`, formatting and `git diff --check` passed. Hook-wide type/circular checks were skipped with `HUSKY=0` for this standalone CJS script change; remote CI remains authoritative for the full suite.
- Consumers must upgrade every installed editor instance to a release containing this fix. Old postinstall scripts can still perform non-atomic writes when mixed with the fixed release.
