### PR TITLE
🐛 fix(vitest): stop collecting the node:test postinstall spec

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
-import { coverageConfigDefaults, defineConfig } from 'vitest/config';
+
+import { configDefaults, coverageConfigDefaults, defineConfig } from 'vitest/config';
 
 import { name } from './package.json';
 
@@ -37,6 +38,7 @@ export default defineConfig({
       statements: 80,
     },
     environment: 'jsdom',
+    exclude: [...configDefaults.exclude, 'scripts/**'],
     globals: true,
     server: {
       deps: {


### PR DESCRIPTION
Unblocks the release pipeline. Release CI has been red on `master` since #213 merged ([run 34371050950](https://github.com/lobehub/lobe-editor/actions/runs/34371050950)), so the concurrent-install fix from that PR never got published — npm's latest `4.27.1` still ships the pre-fix postinstall script byte-for-byte.

### What broke

`scripts/postinstall-lexical-patch.test.cjs`, added in #213, is written against `node:test` and has its own runner step in `test.yml`:

```yaml
- name: Test concurrent postinstall patching
  run: node --test scripts/postinstall-lexical-patch.test.cjs
```

`vitest.config.ts` sets no `test.include`, so Vitest falls back to its default glob `**/*.{test,spec}.?(c|m)[jt]s?(x)` — which matches `.test.cjs`. Vitest loaded the file, node:test ran its case inline (hence the stray `✔` in the log), and Vitest then found zero registered suites:

```
✔ concurrent installers never observe partially written Lexical files (306.985123ms)
❯ scripts/postinstall-lexical-patch.test.cjs (0 test)

FAIL  scripts/postinstall-lexical-patch.test.cjs
Error: No test suite found in file .../scripts/postinstall-lexical-patch.test.cjs

Test Files  1 failed | 77 passed (78)
     Tests  510 passed | 1 skipped (511)
```

The assertion itself passes. Only the collection fails.

### Why Test CI stayed green

The two workflows run different things:

| Workflow | Steps | Runs Vitest? |
| --- | --- | --- |
| Test CI | `node --test scripts/...` + `pnpm run ci` | No — `ci` is `lint:circular && lint && type-check` |
| Release CI | `pnpm run ci` + **`pnpm run test`** + build + release | Yes |

So #213 was green on its branch and only broke once it hit `master`. The Release step sits after Test, so it never ran.

### Fix

Exclude `scripts/**` from Vitest, keeping `configDefaults.exclude` so the built-in `node_modules`/`dist` entries are not clobbered. Each runner owns its own files.

### Verification

- Collection A/B on this checkout — `vitest list --filesOnly | grep -c postinstall-lexical-patch`: **1** on `origin/master`, **0** with this change.
- `vitest run` full suite: **77 files passed, 510 passed / 1 skipped**. Same 510 as the failing CI run, minus the uncollectable file (78 → 77).
- `node --test scripts/postinstall-lexical-patch.test.cjs`: still passes (`pass 1, fail 0`), so the concurrency guard keeps its coverage.

Merging this should let Release CI publish 4.27.2 with #213's atomic patching, which lobe-chat needs — 5 `@lobehub/editor` instances there all resolve to one `lexical@0.42.0` directory, so pnpm races their postinstalls and `pnpm install` fails intermittently.

https://claude.ai/code/session_01UfQZPkguhjsXwvuqdySHB2