### PR TITLE
🐛 fix(react): stop useEditorState from reading a torn-down editor

### DIFF
--- a/src/react/hooks/useEditorState/__tests__/teardown.test.tsx
+++ b/src/react/hooks/useEditorState/__tests__/teardown.test.tsx
@@ -1,0 +1,53 @@
+import { SELECTION_CHANGE_COMMAND } from 'lexical';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import Editor from '@/editor-kernel';
+import { CommonPlugin } from '@/plugins/common';
+
+import { useEditorState } from '..';
+
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+describe('useEditorState teardown', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('drops a pending toolbar update when the host unmounts', () => {
+    const kernel = Editor.createEditor().registerPlugins([CommonPlugin]);
+    const editorRoot = document.createElement('div');
+    document.body.append(editorRoot);
+    kernel.setRootElement(editorRoot);
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    const reactRoot = createRoot(container);
+    const Host = () => {
+      useEditorState(kernel);
+      return null;
+    };
+
+    act(() => {
+      reactRoot.render(<Host />);
+    });
+
+    act(() => {
+      kernel.getLexicalEditor()!.dispatchCommand(SELECTION_CHANGE_COMMAND, undefined);
+    });
+
+    act(() => {
+      reactRoot.unmount();
+    });
+    kernel.destroy();
+
+    const readAfterTeardown = vi.spyOn(kernel, 'getLexicalEditor');
+    expect(() => vi.advanceTimersByTime(2000)).not.toThrow();
+    expect(readAfterTeardown).not.toHaveBeenCalled();
+  });
+});

--- a/src/react/hooks/useEditorState/index.ts
+++ b/src/react/hooks/useEditorState/index.ts
@@ -9,7 +9,12 @@ import { $createQuoteNode, $isHeadingNode, $isQuoteNode } from '@lexical/rich-te
 import { $setBlocksType } from '@lexical/selection';
 import { $getNearestNodeOfType, mergeRegister } from '@lexical/utils';
 import { debounce } from 'es-toolkit';
-import type { LexicalEditor, LexicalNode, TextFormatType } from 'lexical';
+import type {
+  EditorState as LexicalEditorState,
+  LexicalEditor,
+  LexicalNode,
+  TextFormatType,
+} from 'lexical';
 import {
   $createNodeSelection,
   $getSelection,
@@ -160,7 +165,7 @@ export function useEditorState(editor?: IEditor): EditorState {
       setIsStrikethrough(selection.hasFormat('strikethrough'));
       setIsSubscript(selection.hasFormat('subscript'));
       setIsSuperscript(selection.hasFormat('superscript'));
-      setIsCode($isSelectionInCodeInline(lexicalEditor!));
+      setIsCode(!!lexicalEditor && $isSelectionInCodeInline(lexicalEditor));
 
       const anchorNode = selection.anchor.getNode();
       const focusNode = selection.focus.getNode();
@@ -503,15 +508,20 @@ export function useEditorState(editor?: IEditor): EditorState {
         $updateToolbar();
       });
     }, 500);
+    // Both debounces outlive the listeners mergeRegister tears down, so a trailing
+    // call can land after the editor is gone and read a detached kernel.
+    const debounceUpdateListener = debounce(({ editorState }: { editorState: LexicalEditorState }) => {
+      editorState.read(() => {
+        $updateToolbar();
+      });
+    }, 500);
+    const cancelPending = () => {
+      debounceUpdate.cancel();
+      debounceUpdateListener.cancel();
+    };
     const handleLexicalEditor = (lexicalEditor: LexicalEditor) => {
       cleanup = mergeRegister(
-        lexicalEditor.registerUpdateListener(
-          debounce(({ editorState }) => {
-            editorState.read(() => {
-              $updateToolbar();
-            });
-          }, 500),
-        ),
+        lexicalEditor.registerUpdateListener(debounceUpdateListener),
         lexicalEditor.registerCommand(
           SELECTION_CHANGE_COMMAND,
           () => {
@@ -545,11 +555,16 @@ export function useEditorState(editor?: IEditor): EditorState {
     if (!lexicalEditor) {
       editor.on('initialized', handleLexicalEditor);
       return () => {
+        cancelPending();
         cleanup();
         editor.off('initialized', handleLexicalEditor);
       };
     }
-    return handleLexicalEditor(lexicalEditor);
+    handleLexicalEditor(lexicalEditor);
+    return () => {
+      cancelPending();
+      cleanup();
+    };
   }, [editor, $updateToolbar]);
 
   return useMemo(


### PR DESCRIPTION
#### 💻 变更类型 | Change Type

- [ ] ✨ feat
- [x] 🐛 fix
- [ ] ♻️ refactor
- [ ] 💄 style
- [ ] 🔨 chore
- [ ] 📝 docs

#### 🔀 变更说明 | Description of Change

`useEditorState` schedules two 500ms debounced toolbar updates: one wrapping the `registerUpdateListener` callback, one behind `SELECTION_CHANGE_COMMAND`. `mergeRegister` unregisters the listeners on cleanup, but neither debounce is cancelled — a trailing call still fires up to 500ms after the hook unmounts.

When it lands, `$updateToolbar` reads `editor?.getLexicalEditor()`, which is `undefined` once the kernel detached its root or was destroyed. The next line passes it straight to `$isSelectionInCodeInline(lexicalEditor!)`, whose first statement is `editor.getEditorState()`:

```
TypeError: Cannot read properties of null (reading 'getEditorState')
    at $isSelectionInCodeInline (plugins/code/node/code.js)
    at ... readEditorState / EditorState.read
    at invoke (es-toolkit debounce)
    at onTimerEnd
```

The same function already guards the identical value two lines earlier (`if (lexicalEditor) setIsEmpty(...)`); the `!` on the `setIsCode` call hid the nullable type from the checker.

This PR:

- cancels both debounces from the effect cleanup, on every return path (including the `initialized`-listener path)
- replaces `$isSelectionInCodeInline(lexicalEditor!)` with `!!lexicalEditor && $isSelectionInCodeInline(lexicalEditor)`

#### 📝 补充信息 | Additional Information

**Regression test**: `src/react/hooks/useEditorState/__tests__/teardown.test.tsx` mounts the hook on a real kernel, schedules a debounced update, unmounts and destroys the kernel, then advances timers. It fails on `master` (the pending debounce still calls into the kernel) and passes here.

**Verified in a host app**: driving LobeHub's desktop Electron build over CDP — route into a chat page, type, navigate away and back — the stock 4.27.2 package throws this error 6 and 12 times in two runs. With only this package rebuilt and swapped in, the same script on the same routes throws it 0 times in both runs.

https://claude.ai/code/session_01FQvhSDp3pfnpYKbYt2mbS2